### PR TITLE
Add measurement project under adtech_series_sp26/measurement/

### DIFF
--- a/adtech_series_sp26/measurement/README.md
+++ b/adtech_series_sp26/measurement/README.md
@@ -1,0 +1,128 @@
+# Databricks for Ad Tech — Measurement
+
+Session 4 of the Databricks for Ad Tech Spring 2026 series. Computes deduplicated ad-campaign reach via a Spark Declarative Pipeline (COPPA filter → pre-aggregated reach cube), exposes it through a Unity Catalog Function and a governed Metric View, and surfaces results in an AI/BI dashboard and a Genie space.
+
+## Overview
+
+After ad events have been ingested and governed (Session 3), the measurement layer answers the question every advertiser asks: *who did we actually reach?* This project shows how to compute deduplicated reach at any grain (individual / household / IP / email), expose it as a governed semantic layer, and let business users explore it visually and in natural language — all on Databricks.
+
+The sample dataset uses a fictional media conglomerate, MegaCorp, running 7 ad campaigns across CTV, mobile, and web.
+
+## Architecture
+
+```
+<catalog>.bronze.impression_logs_prod   (source impressions, read-only)
+<catalog>.segments.megacorp_campaigns   (audience list, read-only)
+    │
+    │  Spark Declarative Pipeline
+    │  COPPA filter → audience match → struct enrichment
+    │
+    ▼
+<catalog>.silver.reach_impressions      (individual daily aggregation)
+<catalog>.silver.reach_prelim           (campaign-level identity string aggregation)
+    │
+    ▼
+<catalog>.gold.reach_cube               (detail rows + 12 rollup levels)
+<catalog>.gold.reach_individual         (individual-level rows; Metric View source)
+    │
+    ├── <catalog>.gold.compute_reach          (UC Function — scalar reach count)
+    ├── <catalog>.gold.campaign_reach_metrics (Metric View — governed semantic layer)
+    ├── AI/BI Dashboard  (campaign_reach.lvdash.json)
+    └── Genie Space      (campaign_reach_qa.json)
+```
+
+## Databricks Features Demonstrated
+
+| Feature | Where used |
+|---|---|
+| Spark Declarative Pipelines (SDP) | `src/reach_pipeline/transformations/reach_pipeline.py` |
+| Unity Catalog Metric Views (DBR 17.2+, YAML v1.1) | `metric_views/campaign_reach_metrics.sql` |
+| Unity Catalog Functions | `functions/compute_reach.sql` |
+| AI/BI Dashboards as bundle resources | `resources/campaign_reach.dashboard.yml` + `src/dashboards/campaign_reach.lvdash.json` |
+| Genie Spaces (REST API authoring + round-trip) | `genie_spaces/` |
+| Databricks Asset Bundles | `databricks.yml` |
+| Serverless compute + Photon | `resources/reach_pipeline.pipeline.yml` |
+| Pre-aggregated rollup cube for sub-5s dashboard load | `reach_cube` table |
+
+## Prerequisites
+
+| Requirement | Details |
+|---|---|
+| Databricks workspace | DBR 17.2+ serverless runtime (required for Unity Catalog Metric Views) |
+| Unity Catalog | Enabled; target catalog/schema must exist |
+| Databricks CLI | Authenticated against your workspace |
+| Permissions | `CREATE TABLE`, `CREATE FUNCTION`, `CREATE VIEW` on the target schemas |
+| Python | 3.11+, with `databricks-sdk` (for the Genie deploy script) |
+| Source data | `<catalog>.bronze.impression_logs_prod` (impressions) and `<catalog>.segments.megacorp_campaigns` (audience). All locations are overridable via bundle variables. |
+
+> **Note on catalog naming.** SQL files in `functions/`, `metric_views/`, and `tables/` reference `media_advertising.gold` directly. To deploy under a different catalog or schema, either create the `media_advertising` catalog or substitute names with `sed` before running the SQL execute commands. The bundle pipeline (`databricks.yml`) is fully parameterized via the `catalog` / `source_*` / `campaigns_*` variables.
+
+## Deployment
+
+All commands assume a Databricks CLI profile is configured against your workspace. Set `DATABRICKS_CONFIG_PROFILE=<profile>` or pass `--profile <profile>` (omitted below for brevity).
+
+```bash
+# 1. Lookup table (ZIP3 → marketing region)
+databricks sql execute --warehouse-id <warehouse_id> --file tables/zip3_marketing_region.sql
+
+# 2. UC Function + Metric View
+databricks sql execute --warehouse-id <warehouse_id> --file functions/compute_reach.sql
+databricks sql execute --warehouse-id <warehouse_id> --file metric_views/campaign_reach_metrics.sql
+
+# 3. Pipeline + Dashboard (bundle deploys both; pipeline run populates tables)
+databricks bundle deploy --var warehouse_id=<warehouse_id>
+databricks bundle run reach_pipeline
+
+# 4. Genie space (fresh create — prints space_id + URL)
+python genie_spaces/deploy_genie_space.py \
+  --parent-path "/Shared/Adtech-measurement" \
+  --warehouse-id <warehouse_id>
+```
+
+End-to-end walkthrough with verification queries: [docs/quickstart.md](docs/quickstart.md).
+
+## Repository Structure
+
+```
+databricks.yml                           # Bundle config — variables + dev/prod targets
+resources/
+├── reach_pipeline.pipeline.yml          # Pipeline resource definition
+└── campaign_reach.dashboard.yml         # Dashboard resource definition
+src/
+├── reach_pipeline/transformations/
+│   └── reach_pipeline.py                # Pipeline transformations (Python SDP)
+└── dashboards/
+    └── campaign_reach.lvdash.json       # AI/BI Dashboard definition
+functions/
+└── compute_reach.sql                    # UC Function — scalar reach count
+metric_views/
+└── campaign_reach_metrics.sql           # Metric View — governed semantic layer
+tables/
+└── zip3_marketing_region.sql            # ZIP3 → marketing region lookup table
+genie_spaces/
+├── campaign_reach_qa.json               # Space config (instructions, SQL examples, benchmarks)
+├── deploy_genie_space.py                # Create or update via REST API
+└── eval_genie_space.py                  # Verifies question routing (11 cases)
+docs/
+└── quickstart.md                        # Step-by-step deployment + verification
+```
+
+## Key Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Pipeline type | Spark Declarative Pipeline (batch) | `COUNT DISTINCT` requires a full scan; streaming adds no benefit |
+| COPPA filter | Earliest step (temp view) | Flagged records must never enter any aggregation |
+| Reach deduplication | Individual identity key | Present on every impression row; enables correct `COUNT DISTINCT` |
+| Metric View source | Individual-level table (`reach_individual`) | `COUNT DISTINCT` correct at any query grain — pre-aggregated rows would double-count individuals across dimension combinations |
+| Dashboard datasets | Individual-level (KPIs) + cube (Explorer) | KPIs require correct deduplication; Explorer benefits from pre-aggregated rollup rows |
+| Genie data sources | Metric View (primary) + reach cube (impression-volume queries) | `MEASURE()` syntax for reach; cube as the only source for `raw_imps` |
+
+## Series Context
+
+This is **Session 4 of 4** in the Databricks for Ad Tech Spring 2026 series:
+
+1. **Audience Segmentation** — Defining target audiences
+2. **Identity Graphs** — Cross-device identity resolution
+3. **Ad Event Processing** — Impression ingestion, governance, and alerting
+4. **Measurement** — Reach, dashboards, and natural-language Q&A on COPPA-filtered exposure logs ← *this project*

--- a/adtech_series_sp26/measurement/databricks.yml
+++ b/adtech_series_sp26/measurement/databricks.yml
@@ -1,0 +1,39 @@
+bundle:
+  name: adtech-measurement-pipeline
+
+variables:
+  catalog:
+    description: "Unity Catalog catalog for all pipeline outputs"
+    default: media_advertising
+  source_catalog:
+    description: "Catalog containing source impression logs"
+    default: media_advertising
+  source_schema:
+    description: "Schema containing source impression logs"
+    default: bronze
+  source_table:
+    description: "Source impression logs table name"
+    default: impression_logs_prod
+  campaigns_catalog:
+    description: "Catalog containing campaign audience table"
+    default: media_advertising
+  campaigns_schema:
+    description: "Schema containing campaign audience table"
+    default: segments
+  campaigns_table:
+    description: "Campaign audience table name"
+    default: megacorp_campaigns
+  warehouse_id:
+    description: "SQL warehouse ID for dashboard query execution (override via --var warehouse_id=<id>)"
+
+targets:
+  dev:
+    mode: development
+    default: true
+
+  prod:
+    mode: production
+
+
+include:
+  - resources/*.yml

--- a/adtech_series_sp26/measurement/docs/quickstart.md
+++ b/adtech_series_sp26/measurement/docs/quickstart.md
@@ -1,0 +1,213 @@
+# Quickstart
+
+End-to-end deployment of the AdTech Series Measurement project — pipeline, UC Function, Metric View, dashboard, and Genie space — with verification queries at every step.
+
+Substitute `<warehouse_id>` and `<catalog>` for your workspace's values throughout. The bundle's `catalog` variable defaults to `media_advertising`; override with `--var catalog=<your_catalog>` if different.
+
+All `databricks` CLI commands below assume a profile is configured against your workspace — set `DATABRICKS_CONFIG_PROFILE=<profile>` or pass `--profile <profile>` (omitted in examples for brevity).
+
+## Prerequisites
+
+- Databricks CLI authenticated: `databricks auth login --host <your-workspace-host> --profile <profile>`
+- Unity Catalog enabled, with a SQL warehouse accessible to your user
+- DBR 17.2+ serverless runtime available (required for Unity Catalog Metric Views)
+- Permissions: `CREATE TABLE`, `CREATE FUNCTION`, `CREATE VIEW` on the target catalog's schemas
+- Source data in `<catalog>.bronze.impression_logs_prod` and `<catalog>.segments.megacorp_campaigns` (override locations via bundle variables — see `databricks.yml`)
+- Python 3.11+ with `databricks-sdk` installed (`pip install databricks-sdk`)
+
+Verify CLI auth:
+
+```bash
+databricks auth status
+```
+
+## 1. Create the lookup table
+
+ZIP3 → marketing region mapping used by the pipeline.
+
+```bash
+databricks sql execute --warehouse-id <warehouse_id> --file tables/zip3_marketing_region.sql
+```
+
+Validate:
+
+```sql
+SELECT COUNT(*) FROM <catalog>.gold.zip3_marketing_region;
+-- Expected: 961
+
+SELECT * FROM <catalog>.gold.zip3_marketing_region WHERE zip3 = '902';
+-- Expected: 'Los Angeles Metro'
+```
+
+## 2. Create the UC Function
+
+```bash
+databricks sql execute --warehouse-id <warehouse_id> --file functions/compute_reach.sql
+```
+
+Validation deferred to Step 4 — the function reads from `reach_cube`, which doesn't exist until the pipeline runs.
+
+## 3. Create the Metric View
+
+```bash
+databricks sql execute --warehouse-id <warehouse_id> --file metric_views/campaign_reach_metrics.sql
+```
+
+Validation deferred to Step 4 — the view reads from `reach_individual`, which doesn't exist until the pipeline runs.
+
+## 4. Deploy and run the bundle
+
+The bundle deploys the pipeline and the dashboard together. Running the pipeline performs a full refresh of all silver and gold reach tables.
+
+```bash
+databricks bundle deploy --var warehouse_id=<warehouse_id>
+databricks bundle run reach_pipeline
+```
+
+Tables produced:
+
+| Table | Purpose |
+|---|---|
+| `<catalog>.silver.reach_impressions` | Individual-level daily aggregation |
+| `<catalog>.silver.reach_prelim` | Campaign-level identity-string aggregation |
+| `<catalog>.gold.reach_cube` | Detail rows + 12 rollup levels (powers the cube-based dashboard widgets and `compute_reach`) |
+| `<catalog>.gold.reach_individual` | Individual-level rows; source for the Metric View |
+
+Validate the pipeline output:
+
+```sql
+-- reach_cube populated
+SELECT COUNT(*) FROM <catalog>.gold.reach_cube;
+-- Expected: > 0
+
+-- Funnel invariant: raw_imps must always be >= matched_imps
+SELECT COUNT(*) AS violations
+FROM <catalog>.gold.reach_cube
+WHERE raw_imps < matched_imps;
+-- Expected: 0
+
+-- Marketing region populated for every row
+SELECT COUNT(*) FROM <catalog>.gold.reach_cube WHERE marketing_region IS NULL;
+-- Expected: 0
+
+-- Device type breakdown — sample data has 3 values
+SELECT DISTINCT device_type FROM <catalog>.gold.reach_cube;
+-- Expected: CTV, Mobile, Web
+```
+
+Validate the UC Function:
+
+```sql
+-- Returns the campaign-total rollup row's reach_ind
+SELECT <catalog>.gold.compute_reach('Terrific Tacos');
+-- Expected: a non-zero number
+
+-- Function output must equal a direct read of the same rollup row
+SELECT
+  <catalog>.gold.compute_reach('Terrific Tacos', 'Big Mountain') AS fn_reach,
+  reach_ind                                                       AS cube_reach
+FROM <catalog>.gold.reach_cube
+WHERE campaign         = 'Terrific Tacos'
+  AND publisher        = 'Big Mountain'
+  AND device_type      = 'All'
+  AND inventory_type   = 'All'
+  AND content          = 'All'
+  AND marketing_region = 'All';
+-- fn_reach must equal cube_reach
+```
+
+Validate the Metric View:
+
+```sql
+SELECT
+  `Device Type`,
+  MEASURE(`Individual Reach`)          AS reach_ind,
+  MEASURE(`Household Reach`)           AS reach_hhid,
+  MEASURE(`IP Reach`)                  AS reach_ip,
+  MEASURE(`Email Reach`)               AS reach_email,
+  MEASURE(`Total Matched Impressions`) AS matched_imps,
+  MEASURE(`Total Raw Impressions`)     AS raw_imps
+FROM <catalog>.gold.campaign_reach_metrics
+WHERE `Campaign` = 'Terrific Tacos'
+GROUP BY ALL
+ORDER BY reach_ind DESC;
+-- Expected: one row per device_type, all six measures non-zero
+```
+
+Validate the dashboard: open the URL printed by `bundle deploy` and confirm widgets populate. The dashboard is two pages:
+
+- **Campaign Overview** — 6 KPI counters (raw → matched → individual → household → IP → email reach), reach-by-publisher / device-type / inventory / content / region charts, and a campaign → publisher → device-type Sankey
+- **Dimension Explorer** — table of all dimension combinations with 6 filters
+
+## 5. Create the Genie space
+
+The space `AdTech Series — Campaign Reach Q&A` provides natural-language access to the reach data. Its full definition (instructions, SQL examples, benchmarks) lives at `genie_spaces/campaign_reach_qa.json`. The committed JSON has `space_id: null`; populate it after the first deploy if you want a reproducible round-trip.
+
+### Fresh create (first deploy in any workspace)
+
+```bash
+python genie_spaces/deploy_genie_space.py \
+  --parent-path "/Shared/Adtech-measurement" \
+  --warehouse-id <warehouse_id>
+```
+
+Outputs the new `space_id` and URL. Paste the `space_id` into `genie_spaces/campaign_reach_qa.json` and commit if you want subsequent runs to default to it.
+
+### Update an existing space
+
+```bash
+python genie_spaces/deploy_genie_space.py \
+  --space-id <space_id> \
+  --warehouse-id <warehouse_id>
+```
+
+### Deploy to a different catalog/schema
+
+The deploy script rewrites every `media_advertising.gold` reference in the space config to your target.
+
+```bash
+python genie_spaces/deploy_genie_space.py \
+  --catalog <catalog> --schema <schema> \
+  --warehouse-id <warehouse_id> \
+  --parent-path "/Shared/Adtech-measurement"
+```
+
+### Pull latest space back to the repo (after edits in the UI)
+
+```bash
+SPACE_ID=$(python3 -c "import json; print(json.load(open('genie_spaces/campaign_reach_qa.json')).get('space_id') or '')")
+[ -z "$SPACE_ID" ] && { echo "space_id not set in campaign_reach_qa.json"; exit 1; }
+databricks api get "/api/2.0/genie/spaces/${SPACE_ID}?include_serialized_space=true" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+data['serialized_space'] = json.loads(data['serialized_space'])
+data.pop('parent_path', None)  # workspace path — not needed for deploy
+with open('genie_spaces/campaign_reach_qa.json', 'w') as f:
+    json.dump(data, f, indent=2, ensure_ascii=False)
+    f.write('\n')
+print('Saved to genie_spaces/campaign_reach_qa.json')
+"
+```
+
+### Run the routing eval
+
+```bash
+python genie_spaces/eval_genie_space.py --space-id <space_id> --warehouse-id <warehouse_id>
+# Expected: 11/11 passed
+```
+
+The eval covers:
+
+- Cross-dimensional reach breakdowns (must use the Metric View — `reach_cube` rollups only collapse one dimension at a time)
+- Single-dimension reach (Metric View)
+- Campaign-total reach (either source acceptable)
+- Raw vs matched impression comparisons (must use `reach_cube` — only source for `raw_imps`)
+
+## Genie Space — Data Sources & Routing
+
+The space's instructions encode TABLE ROUTING rules:
+
+- `<catalog>.gold.campaign_reach_metrics` (Metric View) — primary source for any reach question. Use `MEASURE()` syntax; correct deduplication at any grain.
+- `<catalog>.gold.reach_cube` (Table) — only source for `raw_imps`. Detail + rollup rows.
+
+Cross-dimensional breakdowns (e.g., publisher × device_type, campaign × publisher) must use the Metric View — `reach_cube` rollup rows only collapse one dimension at a time.

--- a/adtech_series_sp26/measurement/functions/compute_reach.sql
+++ b/adtech_series_sp26/measurement/functions/compute_reach.sql
@@ -1,0 +1,62 @@
+-- UC Function: compute_reach
+-- Feature: AdTech Series Measurement Demo
+--
+-- Purpose: Encode the advertiser's individual reach definition in a single,
+--          catalogued location so every tool (dashboard, Genie, notebooks)
+--          calls the same formula.
+--
+--   Reads rollup rows from reach_cube using the 'All' sentinel:
+--     No-filter call  → publisher = 'All', content = 'All', ... (campaign-total rollup row)
+--     Filtered call   → publisher = p_publisher, content = 'All', ... (single-dim rollup row)
+--
+-- Prerequisites:
+--   media_advertising.gold.reach_cube must exist with rollup rows (created by pipeline).
+--   reach_totals was removed in Phase 11 — do not reference it.
+
+CREATE OR REPLACE FUNCTION media_advertising.gold.compute_reach(
+  p_campaign   STRING   COMMENT 'Campaign name to query reach for. Required.',
+  p_publisher  STRING   DEFAULT NULL COMMENT 'Optional: filter to a specific publisher.',
+  p_content    STRING   DEFAULT NULL COMMENT 'Optional: filter to a specific content title.'
+)
+RETURNS BIGINT
+COMMENT 'Returns the count of distinct individuals (individual reach) exposed to a campaign. \
+COPPA-filtered and deduplicated by mc_indid (megacorp_indid). \
+Reads rollup rows from reach_cube: campaign-total row (all dims = ''All'') for no-filter calls, \
+single-dimension rollup rows for filtered calls. \
+NULL optional parameters mean "all values" — the corresponding dim is matched as ''All''.'
+RETURN (
+  SELECT COALESCE(SUM(reach_ind), 0)
+  FROM   media_advertising.gold.reach_cube
+  WHERE  campaign         = p_campaign
+    AND  publisher        = COALESCE(p_publisher, 'All')
+    AND  content          = COALESCE(p_content,   'All')
+    AND  device_type      = 'All'
+    AND  inventory_type   = 'All'
+    AND  marketing_region = 'All'
+);
+
+-- ── Usage examples ────────────────────────────────────────────────────────────
+
+-- Total individual reach for a campaign (campaign-total rollup row)
+-- SELECT media_advertising.gold.compute_reach('Terrific Tacos');
+-- → 696,592
+
+-- Reach for a specific publisher (publisher rollup row)
+-- SELECT media_advertising.gold.compute_reach('Terrific Tacos', 'Big Mountain');
+
+-- Reach for a specific content title (content rollup row)
+-- SELECT media_advertising.gold.compute_reach('Terrific Tacos', NULL, 'Frasier');
+
+-- Reach for a specific publisher + content (no matching rollup row → returns 0 or partial)
+-- Note: combine publisher + content filtering requires detail-row query, not this function
+-- SELECT media_advertising.gold.compute_reach('Terrific Tacos', 'Rainbow Hemisphere', 'Frasier');
+
+-- Consistency check: function vs rollup row direct query (SC-004)
+-- SELECT
+--   media_advertising.gold.compute_reach('Terrific Tacos', 'Big Mountain') AS fn_reach,
+--   reach_ind AS cube_reach
+-- FROM media_advertising.gold.reach_cube
+-- WHERE campaign = 'Terrific Tacos' AND publisher = 'Big Mountain'
+--   AND device_type = 'All' AND inventory_type = 'All'
+--   AND content = 'All' AND marketing_region = 'All';
+-- fn_reach MUST equal cube_reach

--- a/adtech_series_sp26/measurement/genie_spaces/campaign_reach_qa.json
+++ b/adtech_series_sp26/measurement/genie_spaces/campaign_reach_qa.json
@@ -1,0 +1,452 @@
+{
+  "description": "Ask questions about advertising campaign reach -- individuals, households, and impressions across publishers, content, devices, and regions.",
+  "serialized_space": {
+    "version": 2,
+    "data_sources": {
+      "tables": [
+        {
+          "identifier": "media_advertising.gold.reach_cube"
+        }
+      ],
+      "metric_views": [
+        {
+          "identifier": "media_advertising.gold.campaign_reach_metrics"
+        }
+      ]
+    },
+    "instructions": {
+      "text_instructions": [
+        {
+          "id": "ff362b5eac7240cc919f75ee3c2ddcb8",
+          "content": [
+            "Two data sources are available:\n\n1. campaign_reach_metrics (Metric View — use MEASURE() syntax)\n   Source: reach_individual (individual-level COPPA-filtered gold table).\n   Use for: any reach question at any grain — individual, household, IP, email reach;\n   matched/raw impressions. Always deduplicated via COUNT DISTINCT. Correct at any filter combination.\n   Measures: Individual Reach, Household Reach, IP Reach, Email Reach,\n             Total Matched Impressions, Total Raw Impressions\n\n2. media_advertising.gold.reach_cube (Table — use direct SQL)\n   Use for: raw vs matched impression comparisons, all dimension-combination breakdowns,\n   and pre-aggregated rollup rows. Only source for raw_imps column.\n   Columns: campaign, publisher, device_type, inventory_type, content, marketing_region,\n            reach_ind, reach_hhid, reach_ip, reach_email, matched_imps, raw_imps\n   Row types:\n   - Detail rows: all 6 dims have specific values (publisher != 'All')\n   - Rollup rows: one dim kept, rest = 'All' (e.g. publisher='Big Mountain', device_type='All')\n   - Campaign-total row: all dims = 'All' (publisher='All' AND device_type='All' AND ...)\n\nDecision rule:\n- reach question at any grain → MEASURE() on campaign_reach_metrics\n- raw impressions or matched impressions by dimension → reach_cube\n- all dimension combinations / rollup summary table → reach_cube WHERE publisher != 'All'\n- campaign-level total with rollup → reach_cube WHERE publisher='All' AND device_type='All'\n    AND inventory_type='All' AND content='All' AND marketing_region='All'\n- cross-dimensional breakdown (two or more dims simultaneously, e.g. publisher × device_type,\n  campaign × publisher, publisher × content, content × device_type) → ALWAYS use campaign_reach_metrics,\n  NOT reach_cube, even for 'what content did each publisher serve' style questions where the intent\n  is to see reach by that combination. reach_cube rollup rows only collapse ONE dimension at a time;\n  querying two non-'All' dims from reach_cube will produce incorrect results.\n\nMetric definitions:\n- Individual Reach: distinct COPPA-filtered individuals; correct at any grain (no double-counting)\n- Household Reach: distinct households\n- IP Reach: distinct IP addresses\n- Email Reach: distinct hashed email addresses\n- Total Matched Impressions: impressions surviving COPPA filter AND matched to campaign audience\n- Total Raw Impressions: all impressions before any filtering; raw >= matched always\n\n"
+          ]
+        }
+      ],
+      "example_question_sqls": [
+        {
+          "id": "0359fa05477042c2b87b618826fd58d7",
+          "question": [
+            "Which marketing region had the highest reach?"
+          ],
+          "sql": [
+            "SELECT `Marketing Region`, MEASURE(`Individual Reach`) AS reach FROM media_advertising.gold.campaign_reach_metrics WHERE `Campaign` = 'Terrific Tacos' GROUP BY ALL ORDER BY reach DESC LIMIT 1"
+          ]
+        },
+        {
+          "id": "1dd2b54eb28b4c48921b54edf7dc00d9",
+          "question": [
+            "Which publisher had the highest individual reach for Best Burgers?"
+          ],
+          "sql": [
+            "SELECT `Publisher`, MEASURE(`Individual Reach`) AS reach FROM media_advertising.gold.campaign_reach_metrics WHERE `Campaign` = 'Best Burgers' GROUP BY ALL ORDER BY reach DESC LIMIT 1"
+          ]
+        },
+        {
+          "id": "2406f0e4c83e40488aaedc91935a1433",
+          "question": [
+            "What was the total individual reach for Terrific Tacos?"
+          ],
+          "sql": [
+            "SELECT MEASURE(`Individual Reach`) AS total_reach FROM media_advertising.gold.campaign_reach_metrics WHERE `Campaign` = 'Terrific Tacos' GROUP BY ALL"
+          ]
+        },
+        {
+          "id": "28156c4311ae423a9bfa8e92acb358db",
+          "question": [
+            "Which campaign had the highest individual reach?"
+          ],
+          "sql": [
+            "SELECT `Campaign`, MEASURE(`Individual Reach`) AS reach FROM media_advertising.gold.campaign_reach_metrics GROUP BY ALL ORDER BY reach DESC LIMIT 1"
+          ]
+        },
+        {
+          "id": "31f75471da9045a68f3246fec8a9de87",
+          "question": [
+            "How does CTV reach compare to Mobile reach for Terrific Tacos?"
+          ],
+          "sql": [
+            "SELECT `Device Type`, MEASURE(`Individual Reach`) AS reach FROM media_advertising.gold.campaign_reach_metrics WHERE `Campaign` = 'Terrific Tacos' AND `Device Type` IN ('CTV', 'Mobile') GROUP BY ALL ORDER BY reach DESC"
+          ]
+        },
+        {
+          "id": "363c76f93f964e66bb1b858a45d98b47",
+          "question": [
+            "What is the overall campaign total reach and impressions for Terrific Tacos?"
+          ],
+          "sql": [
+            "SELECT reach_ind, reach_hhid, reach_ip, reach_email, matched_imps, raw_imps FROM media_advertising.gold.reach_cube WHERE campaign = 'Terrific Tacos' AND publisher = 'All' AND device_type = 'All' AND inventory_type = 'All' AND content = 'All' AND marketing_region = 'All'"
+          ]
+        },
+        {
+          "id": "495ce9d8d3bd480c871d4beac9268897",
+          "question": [
+            "What are the raw impressions vs matched impressions for Terrific Tacos by publisher?"
+          ],
+          "sql": [
+            "SELECT publisher, raw_imps, matched_imps, reach_ind FROM media_advertising.gold.reach_cube WHERE campaign = 'Terrific Tacos' AND device_type = 'All' AND inventory_type = 'All' AND content = 'All' AND marketing_region = 'All' AND publisher != 'All' ORDER BY raw_imps DESC"
+          ]
+        },
+        {
+          "id": "5a204d1e4dfb4f0aab46a2b26b22345f",
+          "question": [
+            "Compare raw vs matched impressions by device type for Terrific Tacos"
+          ],
+          "sql": [
+            "SELECT device_type, raw_imps, matched_imps, reach_ind FROM media_advertising.gold.reach_cube WHERE campaign = 'Terrific Tacos' AND publisher = 'All' AND inventory_type = 'All' AND content = 'All' AND marketing_region = 'All' AND device_type != 'All' ORDER BY raw_imps DESC"
+          ]
+        },
+        {
+          "id": "65170df511364fbc883251193eb9bcce",
+          "question": [
+            "What was the CTV reach for Terrific Tacos on Big Mountain?"
+          ],
+          "sql": [
+            "SELECT MEASURE(`Individual Reach`) AS reach FROM media_advertising.gold.campaign_reach_metrics WHERE `Campaign` = 'Terrific Tacos' AND `Publisher` = 'Big Mountain' AND `Inventory Type` = 'CTV' GROUP BY ALL"
+          ]
+        },
+        {
+          "id": "6fd39f319595469384462cb49a59d9bc",
+          "question": [
+            "What was the total individual reach for Best Burgers?"
+          ],
+          "sql": [
+            "SELECT MEASURE(`Individual Reach`) AS total_reach FROM media_advertising.gold.campaign_reach_metrics WHERE `Campaign` = 'Best Burgers' GROUP BY ALL"
+          ]
+        },
+        {
+          "id": "a039110c08254569a7c42d16bc0de876",
+          "question": [
+            "Which marketing regions had the top 5 reach for Terrific Tacos?"
+          ],
+          "sql": [
+            "SELECT `Marketing Region`, MEASURE(`Individual Reach`) AS reach FROM media_advertising.gold.campaign_reach_metrics WHERE `Campaign` = 'Terrific Tacos' GROUP BY ALL ORDER BY reach DESC LIMIT 5"
+          ]
+        },
+        {
+          "id": "b58b10b18895404aa96f4d20f72f887e",
+          "question": [
+            "What is the reach breakdown by inventory type for Terrific Tacos?"
+          ],
+          "sql": [
+            "SELECT `Inventory Type`, MEASURE(`Individual Reach`) AS reach FROM media_advertising.gold.campaign_reach_metrics WHERE `Campaign` = 'Terrific Tacos' GROUP BY ALL ORDER BY reach DESC"
+          ]
+        },
+        {
+          "id": "b819351a31a249bb8e0c2dc232b82d60",
+          "question": [
+            "Show me individual reach for all campaigns ranked."
+          ],
+          "sql": [
+            "SELECT `Campaign`, MEASURE(`Individual Reach`) AS reach FROM media_advertising.gold.campaign_reach_metrics GROUP BY ALL ORDER BY reach DESC"
+          ]
+        },
+        {
+          "id": "e14233348b5f42dfa089fd67bd84a3be",
+          "question": [
+            "Which publisher had the highest individual reach for Terrific Tacos?"
+          ],
+          "sql": [
+            "SELECT `Publisher`, MEASURE(`Individual Reach`) AS reach FROM media_advertising.gold.campaign_reach_metrics WHERE `Campaign` = 'Terrific Tacos' GROUP BY ALL ORDER BY reach DESC LIMIT 1"
+          ]
+        },
+        {
+          "id": "f178897cbcc64f698a035e9c741db683",
+          "question": [
+            "How does household reach compare to individual reach by campaign?"
+          ],
+          "sql": [
+            "SELECT `Campaign`, MEASURE(`Individual Reach`) AS reach_ind, MEASURE(`Household Reach`) AS reach_hhid FROM media_advertising.gold.campaign_reach_metrics GROUP BY ALL ORDER BY reach_ind DESC"
+          ]
+        },
+        {
+          "id": "f73fc21c53814f51a754c6edca1ec241",
+          "question": [
+            "What is the reach for Terrific Tacos across all device types by publisher?"
+          ],
+          "sql": [
+            "SELECT publisher, reach_ind, reach_hhid, matched_imps, raw_imps FROM media_advertising.gold.reach_cube WHERE campaign = 'Terrific Tacos' AND device_type = 'All' AND inventory_type = 'All' AND content = 'All' AND marketing_region = 'All' AND publisher != 'All' ORDER BY reach_ind DESC"
+          ]
+        },
+        {
+          "id": "ff15e083bb434ec7aac45bc6059e969d",
+          "question": [
+            "Show me reach by content title for Terrific Tacos."
+          ],
+          "sql": [
+            "SELECT `Content`, MEASURE(`Individual Reach`) AS reach FROM media_advertising.gold.campaign_reach_metrics WHERE `Campaign` = 'Terrific Tacos' GROUP BY ALL ORDER BY reach DESC"
+          ]
+        },
+        {
+          "id": "ffc34aacee634b208eccc561133e5879",
+          "question": [
+            "Show me all dimension combinations and their reach for Terrific Tacos"
+          ],
+          "sql": [
+            "SELECT publisher, device_type, inventory_type, content, marketing_region, reach_ind, matched_imps, raw_imps FROM media_advertising.gold.reach_cube WHERE campaign = 'Terrific Tacos' AND publisher != 'All' AND device_type != 'All' AND inventory_type != 'All' AND content != 'All' AND marketing_region != 'All' ORDER BY reach_ind DESC"
+          ]
+        }
+      ],
+      "sql_snippets": {
+        "measures": [
+          {
+            "id": "01f128c149ae1e82b13832332f3df180",
+            "alias": "individual_reach",
+            "sql": [
+              "MEASURE(`Individual Reach`) FROM media_advertising.gold.campaign_reach_metrics"
+            ],
+            "display_name": "individual reach (COUNT DISTINCT, correct at any grain)",
+            "instruction": [
+              "WHEN_TO_USE: Whenever the user asks about how many people, individuals, or reach — at any dimensional grain. SCOPE: Use campaign_reach_metrics metric view with MEASURE(`Individual Reach`). GRAIN_SAFE: The MEASURE() wrapper ensures COUNT DISTINCT is computed correctly at any GROUP BY grain without double-counting."
+            ]
+          }
+        ]
+      }
+    },
+    "benchmarks": {
+      "questions": [
+        {
+          "id": "af94e3235f014d9d92428a452d6e29f2",
+          "question": [
+            "How does household reach compare to individual reach by campaign?"
+          ],
+          "answer": [
+            {
+              "format": "SQL",
+              "content": [
+                "SELECT `Campaign`, MEASURE(`Individual Reach`) AS reach_ind, MEASURE(`Household Reach`) AS reach_hhid FROM media_advertising.gold.campaign_reach_metrics GROUP BY ALL ORDER BY reach_ind DESC"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "9538b4e117c64da3968e404f98876923",
+          "question": [
+            "What is the reach breakdown by inventory type for Terrific Tacos?"
+          ],
+          "answer": [
+            {
+              "format": "SQL",
+              "content": [
+                "SELECT `Inventory Type`, MEASURE(`Individual Reach`) AS reach FROM media_advertising.gold.campaign_reach_metrics WHERE `Campaign` = 'Terrific Tacos' GROUP BY ALL ORDER BY reach DESC"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "81a32aff1ece442c94ad51da8078b50a",
+          "question": [
+            "What was the total individual reach for Terrific Tacos?"
+          ],
+          "answer": [
+            {
+              "format": "SQL",
+              "content": [
+                "SELECT MEASURE(`Individual Reach`) AS total_reach FROM media_advertising.gold.campaign_reach_metrics WHERE `Campaign` = 'Terrific Tacos' GROUP BY ALL"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "6895afd3808c4920bcd24abf8e250ec5",
+          "question": [
+            "Show me reach by content title for Terrific Tacos."
+          ],
+          "answer": [
+            {
+              "format": "SQL",
+              "content": [
+                "SELECT `Content`, MEASURE(`Individual Reach`) AS reach FROM media_advertising.gold.campaign_reach_metrics WHERE `Campaign` = 'Terrific Tacos' GROUP BY ALL ORDER BY reach DESC"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "65011a5f9e99404da102c81fe86d4f0c",
+          "question": [
+            "Which marketing regions had the top 5 reach for Terrific Tacos?"
+          ],
+          "answer": [
+            {
+              "format": "SQL",
+              "content": [
+                "SELECT `Marketing Region`, MEASURE(`Individual Reach`) AS reach FROM media_advertising.gold.campaign_reach_metrics WHERE `Campaign` = 'Terrific Tacos' GROUP BY ALL ORDER BY reach DESC LIMIT 5"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "41e35d859eaf43cd977c8bd0df7e17bc",
+          "question": [
+            "How does CTV reach compare to Mobile reach for Terrific Tacos?"
+          ],
+          "answer": [
+            {
+              "format": "SQL",
+              "content": [
+                "SELECT `Device Type`, MEASURE(`Individual Reach`) AS reach FROM media_advertising.gold.campaign_reach_metrics WHERE `Campaign` = 'Terrific Tacos' AND `Device Type` IN ('CTV', 'Mobile') GROUP BY ALL ORDER BY reach DESC"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "4178c40cef7f45a19851e28b25277870",
+          "question": [
+            "Show me individual reach for all campaigns ranked."
+          ],
+          "answer": [
+            {
+              "format": "SQL",
+              "content": [
+                "SELECT `Campaign`, MEASURE(`Individual Reach`) AS reach FROM media_advertising.gold.campaign_reach_metrics GROUP BY ALL ORDER BY reach DESC"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "3f3d9906382a43a894ef572c5ce156ca",
+          "question": [
+            "Which marketing region had the highest reach for Terrific Tacos?"
+          ],
+          "answer": [
+            {
+              "format": "SQL",
+              "content": [
+                "SELECT `Marketing Region`, MEASURE(`Individual Reach`) AS reach FROM media_advertising.gold.campaign_reach_metrics WHERE `Campaign` = 'Terrific Tacos' GROUP BY ALL ORDER BY reach DESC LIMIT 1"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "29e482774a4d41f28a1805e6257ed4dd",
+          "question": [
+            "Which publisher had the highest individual reach for Terrific Tacos?"
+          ],
+          "answer": [
+            {
+              "format": "SQL",
+              "content": [
+                "SELECT `Publisher`, MEASURE(`Individual Reach`) AS reach FROM media_advertising.gold.campaign_reach_metrics WHERE `Campaign` = 'Terrific Tacos' GROUP BY ALL ORDER BY reach DESC LIMIT 1"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "17270b2041be4dba85c6721a4d27907e",
+          "question": [
+            "Which campaign had the highest individual reach?"
+          ],
+          "answer": [
+            {
+              "format": "SQL",
+              "content": [
+                "SELECT `Campaign`, MEASURE(`Individual Reach`) AS reach FROM media_advertising.gold.campaign_reach_metrics GROUP BY ALL ORDER BY reach DESC LIMIT 1"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "ffc6cdb8f8e44abba2735273dc65eca1",
+          "question": [
+            "What is the overall campaign total reach and impressions for Terrific Tacos?"
+          ],
+          "answer": [
+            {
+              "format": "SQL",
+              "content": [
+                "SELECT reach_ind, reach_hhid, reach_ip, reach_email, matched_imps, raw_imps FROM media_advertising.gold.reach_cube WHERE campaign = 'Terrific Tacos' AND publisher = 'All' AND device_type = 'All' AND inventory_type = 'All' AND content = 'All' AND marketing_region = 'All'"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "ce525e26c62d43318a0f7ce6bfab5d50",
+          "question": [
+            "What are the raw impressions vs matched impressions for Terrific Tacos by publisher?"
+          ],
+          "answer": [
+            {
+              "format": "SQL",
+              "content": [
+                "SELECT publisher, raw_imps, matched_imps, reach_ind FROM media_advertising.gold.reach_cube WHERE campaign = 'Terrific Tacos' AND device_type = 'All' AND inventory_type = 'All' AND content = 'All' AND marketing_region = 'All' AND publisher != 'All' ORDER BY raw_imps DESC"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "ca9f4bb6c613491284e147733d7f57dd",
+          "question": [
+            "Compare raw vs matched impressions by device type for Terrific Tacos"
+          ],
+          "answer": [
+            {
+              "format": "SQL",
+              "content": [
+                "SELECT device_type, raw_imps, matched_imps, reach_ind FROM media_advertising.gold.reach_cube WHERE campaign = 'Terrific Tacos' AND publisher = 'All' AND inventory_type = 'All' AND content = 'All' AND marketing_region = 'All' AND device_type != 'All' ORDER BY raw_imps DESC"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "20892ed9b51b47ca8f9630633274ce4b",
+          "question": [
+            "What are the raw impressions vs matched impressions for each campaign?"
+          ],
+          "answer": [
+            {
+              "format": "SQL",
+              "content": [
+                "SELECT campaign, raw_imps, matched_imps, reach_ind FROM media_advertising.gold.reach_cube WHERE publisher = 'All' AND device_type = 'All' AND inventory_type = 'All' AND content = 'All' AND marketing_region = 'All' AND campaign != 'All' ORDER BY raw_imps DESC"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "75ca555833a445b6a4e2ea97c014d7a0",
+          "question": [
+            "What are the raw impressions vs matched impressions for Terrific Tacos by marketing region?"
+          ],
+          "answer": [
+            {
+              "format": "SQL",
+              "content": [
+                "SELECT marketing_region, raw_imps, matched_imps, reach_ind FROM media_advertising.gold.reach_cube WHERE campaign = 'Terrific Tacos' AND publisher = 'All' AND device_type = 'All' AND inventory_type = 'All' AND content = 'All' AND marketing_region != 'All' ORDER BY raw_imps DESC"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "c32b43d7e24041788aee02dfa3a3a517",
+          "question": [
+            "Show me device type breakdown by publisher"
+          ],
+          "answer": [
+            {
+              "format": "SQL",
+              "content": [
+                "SELECT `Publisher`, `Device Type`, MEASURE(`Individual Reach`) AS reach_ind FROM media_advertising.gold.campaign_reach_metrics GROUP BY ALL ORDER BY `Publisher`, reach_ind DESC"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "70ce72fba8b6436b92a49418f399e4f0",
+          "question": [
+            "Which publishers drove the most CTV reach for Moving Movie?"
+          ],
+          "answer": [
+            {
+              "format": "SQL",
+              "content": [
+                "SELECT `Publisher`, MEASURE(`Individual Reach`) AS reach_ind FROM media_advertising.gold.campaign_reach_metrics WHERE `Campaign` = 'Moving Movie' AND `Device Type` = 'CTV' GROUP BY ALL ORDER BY reach_ind DESC"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "space_id": null,
+  "title": "AdTech Series — Campaign Reach Q&A",
+  "warehouse_id": null
+}

--- a/adtech_series_sp26/measurement/genie_spaces/deploy_genie_space.py
+++ b/adtech_series_sp26/measurement/genie_spaces/deploy_genie_space.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Deploy the Campaign Reach Q&A Genie space via the Databricks REST API.
+
+Usage:
+    python deploy_genie_space.py [options]
+
+Examples:
+    # Fresh create — pass --parent-path and --warehouse-id for your workspace
+    python deploy_genie_space.py --parent-path /Shared/Adtech-measurement --warehouse-id <warehouse_id>
+
+    # Deploy to a different catalog/schema
+    python deploy_genie_space.py --catalog dev_catalog --schema gold \
+      --parent-path /Shared/Adtech-measurement --warehouse-id <warehouse_id>
+
+    # Deploy to a specific workspace with a named profile
+    python deploy_genie_space.py --profile <profile> --catalog dev_catalog \
+      --parent-path /Shared/Adtech-measurement --warehouse-id <warehouse_id>
+
+    # Update an existing space instead of creating a new one
+    python deploy_genie_space.py --space-id <space_id> --warehouse-id <warehouse_id>
+
+Requirements:
+    pip install databricks-sdk
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+from databricks.sdk import WorkspaceClient
+
+
+SPACE_CONFIG = Path(__file__).parent / "campaign_reach_qa.json"
+
+
+def substitute_catalog_schema(obj, catalog: str, schema: str):
+    """Recursively replace media_advertising.gold with catalog.schema in all strings."""
+    if isinstance(obj, str):
+        return re.sub(
+            r"\bmedia_advertising\.gold\b",
+            f"{catalog}.{schema}",
+            obj,
+        )
+    if isinstance(obj, list):
+        return [substitute_catalog_schema(item, catalog, schema) for item in obj]
+    if isinstance(obj, dict):
+        return {k: substitute_catalog_schema(v, catalog, schema) for k, v in obj.items()}
+    return obj
+
+
+def build_payload(config: dict, catalog: str, schema: str, warehouse_id: str) -> dict:
+    serialized = config["serialized_space"]
+    serialized = substitute_catalog_schema(serialized, catalog, schema)
+
+    title = substitute_catalog_schema(config["title"], catalog, schema)
+    description = substitute_catalog_schema(config["description"], catalog, schema)
+
+    return {
+        "title": title,
+        "description": description,
+        "warehouse_id": warehouse_id,
+        "serialized_space": json.dumps(serialized),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Deploy Campaign Reach Genie space")
+    parser.add_argument("--profile", default=None, help="~/.databrickscfg profile (default: DEFAULT)")
+    parser.add_argument("--host", default=None, help="Workspace host URL (overrides profile)")
+    parser.add_argument("--catalog", default="media_advertising", help="UC catalog (default: media_advertising)")
+    parser.add_argument("--schema", default="gold", help="UC schema (default: gold)")
+    parser.add_argument("--warehouse-id", default=None, help="SQL warehouse ID (overrides JSON default)")
+    parser.add_argument("--space-id", default=None, help="Update an existing space instead of creating")
+    parser.add_argument("--parent-path", default=None, help="Workspace folder for new space (e.g. /Shared/Adtech-measurement)")
+    args = parser.parse_args()
+
+    # Load config
+    with open(SPACE_CONFIG) as f:
+        config = json.load(f)
+
+    warehouse_id = args.warehouse_id or config.get("warehouse_id")
+    if not warehouse_id:
+        parser.error("--warehouse-id required (no warehouse_id in campaign_reach_qa.json)")
+
+    # Connect
+    client_kwargs = {}
+    if args.host:
+        client_kwargs["host"] = args.host
+    if args.profile:
+        client_kwargs["profile"] = args.profile
+    w = WorkspaceClient(**client_kwargs)
+
+    payload = build_payload(config, args.catalog, args.schema, warehouse_id)
+
+    if args.space_id:
+        print(f"Updating Genie space {args.space_id} ...")
+        result = w.api_client.do(
+            "PATCH",
+            f"/api/2.0/genie/spaces/{args.space_id}",
+            body=payload,
+        )
+        space_id = args.space_id
+        action = "Updated"
+    else:
+        print("Creating Genie space ...")
+        if args.parent_path:
+            payload["parent_path"] = args.parent_path
+        result = w.api_client.do(
+            "POST",
+            "/api/2.0/genie/spaces",
+            body=payload,
+        )
+        space_id = result["space_id"]
+        action = "Created"
+
+    host = w.config.host.rstrip("/")
+    print(f"{action} successfully.")
+    print(f"  Space ID : {space_id}")
+    print(f"  URL      : {host}/genie/rooms/{space_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/adtech_series_sp26/measurement/genie_spaces/eval_genie_space.py
+++ b/adtech_series_sp26/measurement/genie_spaces/eval_genie_space.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""
+Evaluate the Campaign Reach Q&A Genie space against a set of questions.
+
+For each question, checks that the generated SQL uses the expected data source
+(campaign_reach_metrics vs reach_cube) and optionally validates SQL patterns.
+
+Usage:
+    python eval_genie_space.py --space-id <id> [--profile <profile>]
+
+Examples:
+    python eval_genie_space.py --space-id <space_id>
+    python eval_genie_space.py --space-id <space_id> --profile <profile>
+"""
+
+import argparse
+import json
+import re
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from databricks.sdk import WorkspaceClient
+
+
+# ---------------------------------------------------------------------------
+# Evaluation cases
+# ---------------------------------------------------------------------------
+
+@dataclass
+class EvalCase:
+    question: str
+    expected_source: str          # "metric_view" | "reach_cube" | "any"
+    must_contain: list[str] = field(default_factory=list)   # SQL substrings that must appear
+    must_not_contain: list[str] = field(default_factory=list)  # SQL substrings that must NOT appear
+    # result_contains: strings that must appear in the stringified query result rows
+    result_contains: list[str] = field(default_factory=list)
+    description: str = ""
+
+
+EVAL_CASES = [
+    # --- Cross-dimensional: must use Metric View ---
+    EvalCase(
+        question="Show me device type breakdown by publisher",
+        expected_source="metric_view",
+        must_contain=["campaign_reach_metrics"],
+        must_not_contain=["reach_cube"],
+        description="publisher × device_type — cross-dim, must use Metric View",
+    ),
+    EvalCase(
+        question="Which publishers drove the most CTV reach for Moving Movie?",
+        expected_source="metric_view",
+        must_contain=["campaign_reach_metrics"],
+        must_not_contain=["reach_cube"],
+        # Rainbow Hemisphere leads for Moving Movie CTV
+        result_contains=["Rainbow Hemisphere"],
+        description="campaign × publisher × device_type — cross-dim, must use Metric View",
+    ),
+    EvalCase(
+        question="Compare individual reach by publisher across campaigns",
+        expected_source="metric_view",
+        must_contain=["campaign_reach_metrics"],
+        must_not_contain=["reach_cube"],
+        description="campaign × publisher — cross-dim, must use Metric View",
+    ),
+    EvalCase(
+        question="Show me individual reach by content title for each publisher",
+        expected_source="metric_view",
+        must_contain=["campaign_reach_metrics"],
+        must_not_contain=["reach_cube"],
+        description="publisher × content reach — cross-dim, must use Metric View",
+    ),
+    # --- Single-dimension reach: Metric View preferred ---
+    EvalCase(
+        question="What is the total individual reach per campaign?",
+        expected_source="metric_view",
+        must_contain=["campaign_reach_metrics"],
+        # Happy Dogs leads all campaigns
+        result_contains=["Happy Dogs"],
+        description="campaign-level reach — single dim, Metric View",
+    ),
+    EvalCase(
+        question="What was the total individual reach for Terrific Tacos?",
+        expected_source="metric_view",
+        must_contain=["campaign_reach_metrics"],
+        # Known correct value from data
+        result_contains=["696592", "696,592"],
+        description="Terrific Tacos total reach — known value 696,592",
+    ),
+    EvalCase(
+        question="Which publisher had the highest individual reach for Terrific Tacos?",
+        expected_source="metric_view",
+        must_contain=["campaign_reach_metrics"],
+        result_contains=["Rainbow Hemisphere"],
+        description="top publisher for Terrific Tacos — Rainbow Hemisphere",
+    ),
+    EvalCase(
+        question="Which marketing region had the highest reach for Terrific Tacos?",
+        expected_source="metric_view",
+        must_contain=["campaign_reach_metrics"],
+        result_contains=["Dallas"],
+        description="top region for Terrific Tacos — Dallas / Houston Metro",
+    ),
+    EvalCase(
+        question="Show me individual reach by device type",
+        expected_source="metric_view",
+        must_contain=["campaign_reach_metrics"],
+        # CTV should be largest device type
+        result_contains=["CTV"],
+        description="device_type reach — single dim, CTV should appear",
+    ),
+    # --- Raw impressions: reach_cube ---
+    EvalCase(
+        question="Compare raw impressions vs matched impressions by publisher",
+        expected_source="reach_cube",
+        must_contain=["reach_cube"],
+        must_not_contain=["campaign_reach_metrics"],
+        description="raw_imps — must use reach_cube (only source for raw_imps)",
+    ),
+    EvalCase(
+        question="What are the raw impressions vs matched impressions for Terrific Tacos by publisher?",
+        expected_source="reach_cube",
+        must_contain=["reach_cube"],
+        must_not_contain=["campaign_reach_metrics"],
+        # Rainbow Hemisphere has highest raw imps: 4,518,018
+        result_contains=["Rainbow Hemisphere"],
+        description="Terrific Tacos raw/matched by publisher — reach_cube",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Genie API helpers
+# ---------------------------------------------------------------------------
+
+POLL_INTERVAL = 3   # seconds
+MAX_WAIT = 120      # seconds
+
+
+def ask_genie(w: WorkspaceClient, space_id: str, question: str) -> dict:
+    """Start a conversation and return the completed message dict."""
+    resp = w.api_client.do(
+        "POST",
+        f"/api/2.0/genie/spaces/{space_id}/start-conversation",
+        body={"content": question},
+    )
+    conv_id = resp["conversation_id"]
+    msg_id = resp["message_id"]
+
+    deadline = time.time() + MAX_WAIT
+    while time.time() < deadline:
+        msg = w.api_client.do(
+            "GET",
+            f"/api/2.0/genie/spaces/{space_id}/conversations/{conv_id}/messages/{msg_id}",
+        )
+        status = msg.get("status", "")
+        if status in ("COMPLETED", "FAILED", "QUERY_RESULT_EXPIRED", "CANCELLED"):
+            return msg
+        time.sleep(POLL_INTERVAL)
+
+    return {"status": "TIMEOUT", "content": question}
+
+
+def extract_sql(message: dict) -> Optional[str]:
+    """Pull the generated SQL from a completed Genie message."""
+    for attachment in message.get("attachments", []):
+        query = attachment.get("query", {})
+        if query.get("query"):
+            return query["query"]
+    return None
+
+
+def extract_result_rows(message: dict, w: WorkspaceClient, warehouse_id: str) -> Optional[str]:
+    """Return a string representation of the query result rows for value checks.
+
+    First tries to find rows in the Genie message attachments; falls back to
+    executing the SQL directly against the warehouse if results aren't embedded.
+    """
+    # Try embedded rows first
+    for attachment in message.get("attachments", []):
+        result = attachment.get("query", {}).get("query_result", {})
+        rows = result.get("row_results", {}).get("rows", [])
+        if rows:
+            return json.dumps(rows)
+
+    # Fallback: execute the SQL directly
+    sql = extract_sql(message)
+    if not sql:
+        return None
+    try:
+        resp = w.api_client.do(
+            "POST",
+            "/api/2.0/sql/statements/",
+            body={
+                "statement": sql,
+                "warehouse_id": warehouse_id,
+                "format": "JSON_ARRAY",
+                "wait_timeout": "30s",
+            },
+        )
+        result = resp.get("result", {})
+        data = result.get("data_array", [])
+        if data:
+            return json.dumps(data)
+        # Also check manifest for column names
+        manifest = resp.get("manifest", {})
+        columns = [c.get("name", "") for c in manifest.get("schema", {}).get("columns", [])]
+        return json.dumps({"columns": columns, "rows": data})
+    except Exception as e:
+        return f"execution_error: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+def run_eval(w: WorkspaceClient, space_id: str, warehouse_id: str) -> bool:
+    results = []
+    all_passed = True
+
+    for i, case in enumerate(EVAL_CASES, 1):
+        print(f"\n[{i}/{len(EVAL_CASES)}] {case.description or case.question}")
+        print(f"  Q: {case.question}")
+
+        msg = ask_genie(w, space_id, case.question)
+        status = msg.get("status", "UNKNOWN")
+
+        if status != "COMPLETED":
+            print(f"  ✗ FAIL — Genie returned status: {status}")
+            results.append((case, False, f"status={status}", None))
+            all_passed = False
+            continue
+
+        sql = extract_sql(msg)
+        if not sql:
+            print(f"  ✗ FAIL — No SQL in response")
+            results.append((case, False, "no SQL generated", None))
+            all_passed = False
+            continue
+
+        sql_lower = sql.lower()
+        failures = []
+
+        for must in case.must_contain:
+            if must.lower() not in sql_lower:
+                failures.append(f"missing '{must}'")
+
+        for must_not in case.must_not_contain:
+            if must_not.lower() in sql_lower:
+                failures.append(f"unexpected '{must_not}'")
+
+        # Result value checks — verify expected values appear in the returned rows
+        if case.result_contains and not failures:
+            result_str = extract_result_rows(msg, w, warehouse_id) or ""
+            for expected in case.result_contains:
+                # Accept any of the comma-separated alternatives (e.g. "696592,696,592")
+                alternatives = [a.strip() for a in expected.split(",")]
+                if not any(alt.lower() in result_str.lower() for alt in alternatives):
+                    failures.append(f"result missing '{expected}'")
+
+        if failures:
+            print(f"  ✗ FAIL — {', '.join(failures)}")
+            print(f"  SQL: {sql[:300].strip()}...")
+            results.append((case, False, "; ".join(failures), sql))
+            all_passed = False
+        else:
+            print(f"  ✓ PASS")
+            results.append((case, True, "", sql))
+
+    # Summary
+    passed = sum(1 for _, ok, _, _ in results if ok)
+    print(f"\n{'='*60}")
+    print(f"Results: {passed}/{len(results)} passed")
+    if not all_passed:
+        print("\nFailed cases:")
+        for case, ok, reason, sql in results:
+            if not ok:
+                print(f"  - {case.description or case.question}: {reason}")
+    print(f"{'='*60}")
+
+    return all_passed
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Evaluate Genie space question routing")
+    parser.add_argument("--space-id", required=False, help="Genie space ID to evaluate")
+    parser.add_argument("--warehouse-id", default=None, help="SQL warehouse ID (overrides JSON default)")
+    parser.add_argument("--profile", default=None, help="~/.databrickscfg profile")
+    parser.add_argument("--host", default=None, help="Workspace host URL")
+    args = parser.parse_args()
+
+    config_path = Path(__file__).parent / "campaign_reach_qa.json"
+    with open(config_path) as f:
+        config = json.load(f)
+
+    space_id = args.space_id or config.get("space_id")
+    if not space_id:
+        parser.error("--space-id required (no space_id in campaign_reach_qa.json)")
+
+    warehouse_id = args.warehouse_id or config.get("warehouse_id")
+    if not warehouse_id:
+        parser.error("--warehouse-id required (no warehouse_id in campaign_reach_qa.json)")
+
+    client_kwargs = {}
+    if args.host:
+        client_kwargs["host"] = args.host
+    if args.profile:
+        client_kwargs["profile"] = args.profile
+    w = WorkspaceClient(**client_kwargs)
+
+    host = w.config.host.rstrip("/")
+    print(f"Evaluating Genie space: {space_id}")
+    print(f"Workspace: {host}")
+    print(f"Cases: {len(EVAL_CASES)}")
+
+    ok = run_eval(w, space_id, warehouse_id)
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/adtech_series_sp26/measurement/metric_views/campaign_reach_metrics.sql
+++ b/adtech_series_sp26/measurement/metric_views/campaign_reach_metrics.sql
@@ -1,0 +1,135 @@
+-- Metric View: campaign_reach_metrics
+-- Feature: AdTech Series Measurement Demo
+--
+-- Purpose: Expose reach_individual as a governed, queryable metric layer that
+--          AI/BI Genie and dashboards consume natively.
+--          Defines the business vocabulary: six dimensions and six measures.
+--
+-- Prerequisites: media_advertising.gold.reach_cube must exist (created by pipeline).
+-- Runtime requirement: DBR 17.2+ (for YAML version 1.1).
+
+CREATE OR REPLACE VIEW media_advertising.gold.campaign_reach_metrics
+WITH METRICS
+LANGUAGE YAML
+AS $$
+  version: 1.1
+  comment: "Campaign reach KPIs: COPPA-filtered, deduplicated reach metrics across six
+    dimensions (Campaign, Publisher, Device Type, Inventory Type, Content, Marketing Region)
+    and six measures (Individual Reach, Household Reach, IP Reach, Email Reach,
+    Total Matched Impressions, Total Raw Impressions).
+    Source: media_advertising.gold.reach_individual (individual-level gold table, built by the reach pipeline).
+    Do not modify dimension/measure names — Genie space configuration depends on them."
+  source: media_advertising.gold.reach_individual
+
+  dimensions:
+    - name: Campaign
+      expr: campaign
+      comment: "Advertising campaign name (e.g. 'Terrific Tacos', 'Happy Dogs')"
+
+    - name: Publisher
+      expr: publisher
+      comment: "Distribution platform that served the ad"
+
+    - name: Device Type
+      expr: device_type
+      comment: "Device environment: CTV, Mobile, or Web — derived from IFA prefix in request_kv._server_ifa"
+
+    - name: Inventory Type
+      expr: inventory_type
+      comment: "Ad buying channel: CTV (premium/guaranteed deals), Mobile, or Other (open/standard) — derived from IFA prefix"
+
+    - name: Content
+      expr: content
+      comment: "Title of the content in which the ad appeared"
+
+    - name: Marketing Region
+      expr: marketing_region
+      comment: "Named US advertising market derived from ZIP code prefix via zip3_marketing_region lookup table"
+
+  measures:
+    - name: Individual Reach
+      expr: COUNT(DISTINCT mc_indid)
+      comment: "Count of distinct individuals reached (COPPA-filtered, deduplicated by mc_indid). Correct at any query grain — no double-counting across dimension combinations."
+
+    - name: Household Reach
+      expr: COUNT(DISTINCT hhid)
+      comment: "Count of distinct households reached (deduplicated by megacorp_hhid from the campaign audience list). Correct at any query grain."
+
+    - name: IP Reach
+      expr: COUNT(DISTINCT ip_address)
+      comment: "Count of distinct IP addresses reached across the campaign audience. Correct at any query grain."
+
+    - name: Email Reach
+      expr: COUNT(DISTINCT server_email)
+      comment: "Count of distinct email addresses reached (sourced from request_kv._server_email). Correct at any query grain."
+
+    - name: Total Matched Impressions
+      expr: SUM(imps)
+      comment: "Impressions surviving COPPA exclusion AND matched to the campaign audience via INNER JOIN."
+
+    - name: Total Raw Impressions
+      expr: SUM(raw_imps_kpi)
+      comment: "All impressions before any filtering — total raw inventory served for this campaign. raw_imps_kpi is additive at any query grain via ROW_NUMBER attribution in reach_individual."
+$$;
+
+-- ── Sample queries ────────────────────────────────────────────────────────────
+
+-- Individual reach by publisher for a campaign
+-- SELECT
+--   `Publisher`,
+--   MEASURE(`Individual Reach`)          AS reach_ind,
+--   MEASURE(`Household Reach`)           AS reach_hhid,
+--   MEASURE(`Total Matched Impressions`) AS matched_imps
+-- FROM media_advertising.gold.campaign_reach_metrics
+-- WHERE `Campaign` = 'Terrific Tacos'
+-- GROUP BY ALL
+-- ORDER BY reach_ind DESC;
+
+-- Reach by device type (CTV vs Mobile vs Web)
+-- SELECT
+--   `Device Type`,
+--   MEASURE(`Individual Reach`) AS reach
+-- FROM media_advertising.gold.campaign_reach_metrics
+-- WHERE `Campaign` = 'Terrific Tacos'
+-- GROUP BY ALL
+-- ORDER BY reach DESC;
+
+-- Reach by inventory type (CTV premium vs Mobile vs Other open)
+-- SELECT
+--   `Inventory Type`,
+--   MEASURE(`Individual Reach`) AS reach
+-- FROM media_advertising.gold.campaign_reach_metrics
+-- WHERE `Campaign` = 'Terrific Tacos'
+-- GROUP BY ALL
+-- ORDER BY reach DESC;
+
+-- Impression funnel (raw → matched → individual → household)
+-- SELECT
+--   MEASURE(`Total Raw Impressions`)     AS raw_imps,
+--   MEASURE(`Total Matched Impressions`) AS matched_imps,
+--   MEASURE(`Individual Reach`)          AS reach_ind,
+--   MEASURE(`Household Reach`)           AS reach_hhid
+-- FROM media_advertising.gold.campaign_reach_metrics
+-- WHERE `Campaign` = 'Terrific Tacos'
+-- GROUP BY ALL;
+
+-- Top marketing regions by individual reach
+-- SELECT
+--   `Marketing Region`,
+--   MEASURE(`Individual Reach`) AS reach
+-- FROM media_advertising.gold.campaign_reach_metrics
+-- WHERE `Campaign` = 'Terrific Tacos'
+-- GROUP BY ALL
+-- ORDER BY reach DESC
+-- LIMIT 10;
+
+-- ── Genie integration note ────────────────────────────────────────────────────
+-- When configuring the Genie space:
+-- 1. Add campaign_reach_metrics as the dataset
+-- 2. Genie maps "Campaign" → "for Terrific Tacos", "for Happy Dogs"
+-- 3. Genie maps "Publisher" → "on Big Mountain", "by publisher"
+-- 4. Genie maps "Device Type" → "on CTV", "on mobile devices"
+-- 5. Genie maps "Inventory Type" → "on premium inventory", "on open inventory"
+-- 6. Genie maps "Marketing Region" → "in Los Angeles Metro", "in Chicago Metro"
+-- 7. Genie maps "Individual Reach" → "how many people reached", "reach count"
+-- 8. MEASURE() wrapper is handled by Genie internally — no manual SQL needed

--- a/adtech_series_sp26/measurement/resources/campaign_reach.dashboard.yml
+++ b/adtech_series_sp26/measurement/resources/campaign_reach.dashboard.yml
@@ -1,0 +1,9 @@
+resources:
+  dashboards:
+    campaign_reach:
+      display_name: "AdTech Series — Campaign Reach"
+
+      file_path: ../src/dashboards/campaign_reach.lvdash.json
+
+      # SQL warehouse that executes dashboard queries.
+      warehouse_id: ${var.warehouse_id}

--- a/adtech_series_sp26/measurement/resources/reach_pipeline.pipeline.yml
+++ b/adtech_series_sp26/measurement/resources/reach_pipeline.pipeline.yml
@@ -1,0 +1,29 @@
+resources:
+  pipelines:
+    reach_pipeline:
+      name: "AdTech Reach Measurement Pipeline"
+
+      # Target catalog and schema — all new tables land here.
+      # DO NOT change: all existing tables in media_advertising.gold must not be overwritten.
+      catalog: ${var.catalog}
+      schema: gold
+
+      # Serverless compute — required for Unity Catalog Metric Views (DBR 17.2+).
+      serverless: true
+
+      root_path: ../src/reach_pipeline
+
+      libraries:
+        - file:
+            path: ../src/reach_pipeline/transformations/reach_pipeline.py
+
+      # Pipeline parameters — accessed in Python via spark.conf.get("key").
+      # Changing source_catalog/source_schema/source_table here updates the
+      # entire pipeline without touching transformation code.
+      configuration:
+        source_catalog: ${var.source_catalog}
+        source_schema: ${var.source_schema}
+        source_table: ${var.source_table}
+        campaigns_catalog: ${var.campaigns_catalog}
+        campaigns_schema: ${var.campaigns_schema}
+        campaigns_table: ${var.campaigns_table}

--- a/adtech_series_sp26/measurement/src/dashboards/campaign_reach.lvdash.json
+++ b/adtech_series_sp26/measurement/src/dashboards/campaign_reach.lvdash.json
@@ -1,0 +1,1182 @@
+{
+  "datasets": [
+    {
+      "name": "ucmv_data",
+      "displayName": "Campaign Reach (UCMV)",
+      "queryLines": [
+        "SELECT\n",
+        "  campaign,\n",
+        "  publisher,\n",
+        "  device_type,\n",
+        "  inventory_type,\n",
+        "  content,\n",
+        "  marketing_region,\n",
+        "  mc_indid,\n",
+        "  hhid,\n",
+        "  ip_address,\n",
+        "  server_email,\n",
+        "  imps,\n",
+        "  raw_imps_kpi\n",
+        "FROM\n",
+        "  media_advertising.gold.reach_individual"
+      ]
+    },
+    {
+      "name": "cube_detail_data",
+      "displayName": "Dimension Combinations (Detail)",
+      "queryLines": [
+        "SELECT\n",
+        "  campaign,\n",
+        "  publisher,\n",
+        "  device_type,\n",
+        "  inventory_type,\n",
+        "  content,\n",
+        "  marketing_region,\n",
+        "  reach_ind,\n",
+        "  reach_hhid,\n",
+        "  reach_ip,\n",
+        "  reach_email,\n",
+        "  matched_imps,\n",
+        "  raw_imps\n",
+        "FROM\n",
+        "  media_advertising.gold.reach_cube"
+      ]
+    }
+  ],
+  "pages": [
+    {
+      "name": "overview",
+      "displayName": "Campaign Overview",
+      "layout": [
+        {
+          "widget": {
+            "name": "title",
+            "multilineTextboxSpec": {
+              "lines": [
+                "## Campaign Reach Dashboard"
+              ]
+            }
+          },
+          "position": {
+            "x": 1,
+            "y": 0,
+            "width": 15,
+            "height": 1
+          }
+        },
+        {
+          "widget": {
+            "name": "subtitle",
+            "multilineTextboxSpec": {
+              "lines": [
+                "COPPA-filtered, deduplicated reach metrics. Use the Campaign filter to explore any campaign."
+              ]
+            }
+          },
+          "position": {
+            "x": 1,
+            "y": 1,
+            "width": 15,
+            "height": 1
+          }
+        },
+        {
+          "widget": {
+            "name": "kpi-ind-reach",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "ucmv_data",
+                  "fields": [
+                    {
+                      "name": "countdistinct(mc_indid)",
+                      "expression": "COUNT(DISTINCT `mc_indid`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "counter",
+              "encodings": {
+                "value": {
+                  "fieldName": "countdistinct(mc_indid)",
+                  "displayName": "Individual Reach"
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Individual Reach"
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 2,
+            "width": 4,
+            "height": 3
+          }
+        },
+        {
+          "widget": {
+            "name": "kpi-hh-reach",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "ucmv_data",
+                  "fields": [
+                    {
+                      "name": "countdistinct(hhid)",
+                      "expression": "COUNT(DISTINCT `hhid`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "counter",
+              "encodings": {
+                "value": {
+                  "fieldName": "countdistinct(hhid)",
+                  "displayName": "Household Reach"
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Household Reach"
+              }
+            }
+          },
+          "position": {
+            "x": 4,
+            "y": 2,
+            "width": 4,
+            "height": 3
+          }
+        },
+        {
+          "widget": {
+            "name": "kpi-matched-imps",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "ucmv_data",
+                  "fields": [
+                    {
+                      "name": "sum(imps)",
+                      "expression": "SUM(`imps`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "counter",
+              "encodings": {
+                "value": {
+                  "fieldName": "sum(imps)",
+                  "displayName": "Matched Impressions"
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Matched Impressions"
+              }
+            }
+          },
+          "position": {
+            "x": 8,
+            "y": 2,
+            "width": 4,
+            "height": 3
+          }
+        },
+        {
+          "widget": {
+            "name": "kpi-ip-reach",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "ucmv_data",
+                  "fields": [
+                    {
+                      "name": "countdistinct(ip_address)",
+                      "expression": "COUNT(DISTINCT `ip_address`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "counter",
+              "encodings": {
+                "value": {
+                  "fieldName": "countdistinct(ip_address)",
+                  "displayName": "IP Reach"
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "IP Reach"
+              }
+            }
+          },
+          "position": {
+            "x": 12,
+            "y": 2,
+            "width": 4,
+            "height": 3
+          }
+        },
+        {
+          "widget": {
+            "name": "kpi-email-reach",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "ucmv_data",
+                  "fields": [
+                    {
+                      "name": "countdistinct(server_email)",
+                      "expression": "COUNT(DISTINCT `server_email`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "counter",
+              "encodings": {
+                "value": {
+                  "fieldName": "countdistinct(server_email)",
+                  "displayName": "Email Reach"
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Email Reach"
+              }
+            }
+          },
+          "position": {
+            "x": 16,
+            "y": 2,
+            "width": 4,
+            "height": 3
+          }
+        },
+        {
+          "widget": {
+            "name": "kpi-raw-imps",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "ucmv_data",
+                  "fields": [
+                    {
+                      "name": "sum(raw_imps_kpi)",
+                      "expression": "SUM(`raw_imps_kpi`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "counter",
+              "encodings": {
+                "value": {
+                  "fieldName": "sum(raw_imps_kpi)",
+                  "displayName": "Raw Impressions"
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Raw Impressions"
+              }
+            }
+          },
+          "position": {
+            "x": 20,
+            "y": 2,
+            "width": 4,
+            "height": 3
+          }
+        },
+        {
+          "widget": {
+            "name": "bar-publisher",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "ucmv_data",
+                  "fields": [
+                    {
+                      "name": "publisher",
+                      "expression": "`publisher`"
+                    },
+                    {
+                      "name": "countdistinct(mc_indid)",
+                      "expression": "COUNT(DISTINCT `mc_indid`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "bar",
+              "encodings": {
+                "x": {
+                  "fieldName": "publisher",
+                  "scale": {
+                    "type": "categorical",
+                    "sort": {
+                      "by": "y-reversed"
+                    }
+                  },
+                  "displayName": "Publisher"
+                },
+                "y": {
+                  "fieldName": "countdistinct(mc_indid)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Individual Reach"
+                },
+                "label": {
+                  "show": true
+                },
+                "color": {
+                  "fieldName": "publisher",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "Publisher"
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Reach by Publisher"
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 5,
+            "width": 24,
+            "height": 5
+          }
+        },
+        {
+          "widget": {
+            "name": "pie-device",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "ucmv_data",
+                  "fields": [
+                    {
+                      "name": "device_type",
+                      "expression": "`device_type`"
+                    },
+                    {
+                      "name": "countdistinct(mc_indid)",
+                      "expression": "COUNT(DISTINCT `mc_indid`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "pie",
+              "encodings": {
+                "angle": {
+                  "fieldName": "countdistinct(mc_indid)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Individual Reach"
+                },
+                "color": {
+                  "fieldName": "device_type",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "Device Type"
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Reach by Device Type"
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 10,
+            "width": 12,
+            "height": 5
+          }
+        },
+        {
+          "widget": {
+            "name": "bar-inventory",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "ucmv_data",
+                  "fields": [
+                    {
+                      "name": "inventory_type",
+                      "expression": "`inventory_type`"
+                    },
+                    {
+                      "name": "countdistinct(mc_indid)",
+                      "expression": "COUNT(DISTINCT `mc_indid`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "bar",
+              "encodings": {
+                "x": {
+                  "fieldName": "inventory_type",
+                  "scale": {
+                    "type": "categorical",
+                    "sort": {
+                      "by": "y-reversed"
+                    }
+                  },
+                  "displayName": "Inventory Type"
+                },
+                "y": {
+                  "fieldName": "countdistinct(mc_indid)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Individual Reach"
+                },
+                "label": {
+                  "show": true
+                },
+                "color": {
+                  "fieldName": "inventory_type",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "Inventory Type"
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Reach by Inventory Type"
+              }
+            }
+          },
+          "position": {
+            "x": 12,
+            "y": 10,
+            "width": 12,
+            "height": 5
+          }
+        },
+        {
+          "widget": {
+            "name": "bar-content2",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "ucmv_data",
+                  "fields": [
+                    {
+                      "name": "content",
+                      "expression": "`content`"
+                    },
+                    {
+                      "name": "countdistinct(mc_indid)",
+                      "expression": "COUNT(DISTINCT `mc_indid`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "bar",
+              "encodings": {
+                "x": {
+                  "fieldName": "countdistinct(mc_indid)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Individual Reach"
+                },
+                "y": {
+                  "fieldName": "content",
+                  "scale": {
+                    "type": "categorical",
+                    "sort": {
+                      "by": "x-reversed"
+                    }
+                  },
+                  "displayName": "Content"
+                },
+                "label": {
+                  "show": true
+                },
+                "color": {
+                  "fieldName": "content",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "Content",
+                  "legend": {
+                    "hide": true
+                  }
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Individual Reach by Content Title"
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 48,
+            "width": 24,
+            "height": 15
+          }
+        },
+        {
+          "widget": {
+            "name": "table-region",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "ucmv_data",
+                  "fields": [
+                    {
+                      "name": "marketing_region",
+                      "expression": "`marketing_region`"
+                    },
+                    {
+                      "name": "countdistinct(mc_indid)",
+                      "expression": "COUNT(DISTINCT `mc_indid`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "bar",
+              "encodings": {
+                "x": {
+                  "fieldName": "countdistinct(mc_indid)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Individual Reach"
+                },
+                "y": {
+                  "fieldName": "marketing_region",
+                  "scale": {
+                    "type": "categorical",
+                    "sort": {
+                      "by": "x-reversed"
+                    }
+                  },
+                  "displayName": "Marketing Region"
+                },
+                "color": {
+                  "fieldName": "marketing_region",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "Marketing Region",
+                  "legend": {
+                    "hide": true
+                  }
+                },
+                "label": {
+                  "show": true
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Reach by Marketing Region"
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 30,
+            "width": 24,
+            "height": 18
+          }
+        },
+        {
+          "widget": {
+            "name": "filter-campaign-p1",
+            "queries": [
+              {
+                "name": "ds_filter-campaign-p1",
+                "query": {
+                  "datasetName": "ucmv_data",
+                  "fields": [
+                    {
+                      "name": "campaign",
+                      "expression": "`campaign`"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "filter-multi-select",
+              "encodings": {
+                "fields": [
+                  {
+                    "fieldName": "campaign",
+                    "displayName": "Campaign",
+                    "queryName": "ds_filter-campaign-p1"
+                  }
+                ]
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Campaign"
+              }
+            }
+          },
+          "position": {
+            "x": 16,
+            "y": 0,
+            "width": 8,
+            "height": 2
+          }
+        },
+        {
+          "widget": {
+            "name": "logo-megacorp",
+            "multilineTextboxSpec": {
+              "lines": [
+                "![Megacorp Logo](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAABECAYAAAAWVrIgAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAUKADAAQAAAABAAAARAAAAACkgH0NAAAZo0lEQVR4Ae1ce3RdRbmf2Y9zTt5JkzTPPoAiYF9A+khL0QgVWoHSB0EF9eJCkYWPu66ue3Wte9WoVEXRK3e5WOJVQFFEA20pjwqCRNr0XVuE8tC0tEl60iRN0jzPY+89c3/fnEdOkvPYTXKX/YNpT/beM998880332Pmm9mbVy3f+BV2jklqGmdS/Nm/d8tfz7HqGPDSpfXlHt2+TUoGhFyOKYw+SCY5ymwpuY1mubDlLv/Bpw4ng02eV6+zud1mla8oxymSF+nCvERK+0bGeC3jzGFMAisbAA2/ZprW4jD7mBjof7c7lGWxlh1h4ExKV6wtA5Xujz24vWqazoTt/Imx+rWMNYKIySUPt+/kuudeJlKj4FHU6op2mQj/B7LcMFCrrLnJx712LRMlmzAQdZqUFzFNejnTmATHIgmygBuuaT9EJtOlMaDnFb9Zlc+ft2du2Nrp72thJ5pCAIlViNaLXAyZhvgxkAkPVIdzXjfrqvDKtma2M6HI9W3h5esLpcY+LR0bpAnX9cBIVMiQ5q31Vhb7loIrX5VCrgGtBgdziGlSJh+s0XyeD/haklDd0f61qrz4V7L05p/4D3j8yYRFy0BK6mKumY7FvwiASeHI9rBNnOsXnQvzUhMzWlK9oj6rsjj73xjXnwMjbgTHICQ2Lm4HCUwWAj+ME5fF0NAvM8PYUbXCqmOszhhtKXI3qc5TVSW5XL+hdOX6ReORZnyeW+eDHf1cCq3IWD0VwOxVNxQ5wv4Z1/j3oOv5k9GuMbhJYqEhkPr5TOhPVqyYcRPMFuzIaJo0AwkFCM02HX4P3Y6izHxXXV7yIVRYQiM9XankknV5luX9uaYbn1KMQ+enKyk6OSvUBH+4Yll4ZSLeKTGQ1AIe8tbSyzfNS0Sa4V4TUnyeg/sZ4NwX19SYniLj+3Butyib6qomFyDBgUNxNYrKBGi8ECr9YF7NTSWxJqbEQBgWWEC9wJslPguErhhSvvKjNZg2rJ6yesV6gHarzDm3YyDvUXZrND/pHZhGBnEY1L6G8X9JcrEbhHfAC5OnTZuIZo0bC/I9+pcAqPo7NQYCC3kvaOKnihfXV6ZtPVLINTt8F3Tf6wLWFUhRzU2zMI73ulFYSKiFycjzhoevYZa1yr9vyxr/LKNON7NWgRvfxdSiJ5MYUH+l4HeV1FxfTgRO8CquqE4EAvVc08u8PvsuZDfgl7IvlStuuoQJXj99tq9ezzasr0ILqtJKH7jDmR52hHgwpyfwtZaWHaPS1tjotDJ2HHR/u2rp+map64/C+1Yr7ULmhBTtr0fP3YSyn05ZAqkBzLVoXngHVhZlExoczcCM1bgDqlKQhsej0C7uZtVYc7FO+Xgmc0ATZ7jTXdy2/nMM88a1cerAtpeZkA1gt3K944rHPErN+Qgy+LQwEFMGQjXbwLKMkI5pKfpQcsW6Ci757dMnfYw5pppLFqUdEFCDCXQYerHZf+iZkWS0JeZpuv44aryuprfUkyQ/ciia1BYVrLqh0D0Dk7IloWmSQsY+M3vVbYUJufFb02PWw4NVp+1sHNrNTZ0BP7o+papFUahlGxNHyp1SVyum9j2NAeDcBk2xYYtS/7gozbKyK1zbQCCDy2djJpGJ3ZSQQqwsLrPDIxuR/8vEMrZ8bb7GxZ1MpBwviLAMAUFWags6BiMrry2sBk3zMzGQlAyzlRcOHfq5NRZD6idd5zukI1an7CyIpPiHLm3THQPBOYz221ITl2K6oKfsJE1ruHY3W3TdE+xvLw7HSKwS2WvA+oXE5AkJcxowoQ3i+w9Iy+qkMBMqYSQ5X4BASn5GeHhNOI99SVCkzGrbveUAloTXp1ulgmrWXs3CrhiISS945jwJG1YPKXl/KjVUk03Oa6qz8ta0M/aUonB+vYdpzt2piCHcgjlbgBtwfHXKwRnXXYS33k914cHGlSQ80thAsrmtH0/IdXWrVNkFZEqdGlsXcqdpJxCa+xWkBGKWOqGcY2b4BYaICEFV51krIV2rRqMdCXWV8ImgZjDgJVE8hyTlvFQDOYpFhaoGZI5xZjRveu9cMhB+VgqP6WWPQWXOpOsrMQqz/VWzi30foIU3fAtJn5mM7KgE7Tq1a+trkktPMpiUeVxWpCxLKIDpGdIKi+LmJKFoWm5dMxASYp7cuaUD+vYkebZ0iUvNQNTtrlkrRy4DNz+iVHt8BaVeEFbGow7HpQTyaORa8ozzSdAM9DLoP96XOYY4nj6Xz+k5kQSJwZ2fwh5mlEJYpusd6XkQti0vuaqhaWEfyTOc55I0kzIrZvHAbp9LeymZryit2UnZmIuCc2Zg676n34JLeRorj7ToUZqHZdvVqbwkpAOTGv2xd5q3D6ZFNK4wTjDNJNyl9IS6w5ESKk5PSoiJBdBIqJ1gg6Qh6VOKPoL5sJV+YYe3pq+fuhS2NZDOFlNN1TrnZrUnx9VsI3VrqUsmw0B2KnvxAUw9XsYCPTXmNCVKeiXfiqVVaxqw5EWYv1ABZjC9yQESc2l1JLM1vdOXmDud95MbmaYGW1+y6X+x23A9KHS9elCEo/tYmw5quvjN1DrCT2WsDxGEzcw37RE4HNaXET4RAPPXSl8wzh/N45ugTiIc5HGAxLqu7i/QXmFt9n5I4QfhVFxVISCSWkRPXp2Xfflf29k21/UmAvJ/TMwbn0OhNi0rbMgqlJwYX5rumeavUvfMcSxaDmtc2iEH066EjqIfmhGaNAPbGxsDFcvX/ULn2koolenKpCvlk2HNkI80QYrTdSBTGfal/6abOnUorR2Bs9JlWFwOuOZMOOPldXWGCPBvccFWarTaUcmAMI8KoVoEMfZcrDRe91xuTDP3OUyw30y1TJuIiza0xVuekPnSxLJzy8nNMo8iDnmajGH6pNz1Ncm2JFPVqw4UXwBVWQj8JGCRH030ORv9YV6sS/nbTK2nakPlt+56vA+NPAKnkCDaqavQ1AWlvzl+qLE/NZS7kpadjVieyVczTaeiwd6r564onucOc73uCPlRqGvqOKOy4/YgwipHpsRAIkg3zCdxNONkRklQUxfR6UgjEmRw15t0UIgoyT9ApMOQjDRJRctLw1LeU3LVOkzq0yZecZW4Aoz5TPoYhY4m+V9nhma2TpmBiFqcwojdjz7EFglJKYxIivxZ5/7Gd5MCTCYz7LwIj/58JhNCUXB0+LNeW/9O2YqbFzLYuPHNldRsrKhaseGTcBO/RF/mpO4OSrkMSak9QDHGCYjGI3bzbHrE047NvwQpvDRpeImkT8hOZmt/cIPPLQyF6MuWrv+pYehXQc5KIY2pq0pJpyHuNKQ2qzpY/BexbH0r4IeEDlsm+Eypy6Vwq9fBLFxMZ2hSJlqBOaLZ8IT/QjDTwsC25u3+8uUbH9c5+3aytin4gNNpf3xf3tkWf0rKJleQVxLaNdKXRXb4y+i2kYqJypUImQvx2Sg4uxo7eSCFD8KFexAonolwUzUky8jEPLTTDb//3627nlPzyimrcKzbBgs/ASlrn7C8ohFjchhhpV83NTVNaeoSayvx2rJjRwinvB5E28+qfNVeIsTYe2Ik4jml0InF+K2Cqi4DhXMB5YZ5QeE4Pze9BfFZxLQxsH3tkmOCi60TQ10gU4r9dmFu2rA6JNeVJx/LjshTx+4tJ3XJN0PMX0AOeY1kYPE8YiJJGoXZItc0Kku1gA//ggB/zDC9D55oejQYQzZtDGQNDeCf+DXI6qHmEhJJ3WOdLz6WNqgJqZg0A6mttv1PHcSZgQa03YjHQRWspYIppiieLvTrF7bt3NfW/MQYK+SSgWMYkpKkDqf8NVjYF7B9qWAijcsWmznwlJkSOfFM7aQv79y3Za8j7W8B6gGI4WFog0U0jBvQTIQoeFWPawHIZjPq34cBvq/r0LZj4ysbEM+0khGpgIA7vMD4yhOeaeuwdtMjGK0PA28OGAK5En/oOrC9cwLsuAycMAhD2UdQL40+AYpODaRJp/c9/SZOv/4o2ysPwuBfiwnMleDIxdDaYjzDZ9AgJGsC+REPSPPKLtDxd6j3AQC/BGY2t+/FfnGSRF444xlpCiDpQhxOUn9ilhXezQ3zPtTJU8FU6fxuItDEHJy6flFw/WzSvkXBI4EseXBi7bE5Z49sO3uWsadnLl+312D6Ihykuwye9yLMF8sxuDMgmRQlR4iLY4cM0U3GAhiaATCuB7PZU2Dv32FQ3h4JBN/ofz3ibce2MPrEcRA7e/Qx+Z1jhXjnjHCIufSi87AjN5jtGLrplW6OU6hWET4q0/tNqpOcChiHc6RjFE+9Xn4Fm4ED5yWQ4BkCp1cRD/dRUJx0BNoVBJNpedmje8LdmKKA/+mGchTze3dT5ACfU7vhsiniyFgdNgSrKU2jTZCMwP9kAJxw1Qyc2khvi0GkYXArGOw2cGDkN//vNNPKnAIx5APO94RNbYu2DSIOJSW13IF70rVGLH3YlSmhprsgnYOd7rYmi88tjbDUEIlnp2Ut7JrWlO7BNYbzBxC6pDm8z+VE+vyh+7yihMvUB/bOK0LPY2Lek8ApDs57DJwiA8/RifxzZyHnGhSYIm/SV6fdQExwDU1yOtPsLuGNZyyDkp71c4dgclBgHN6Kxqu8kz1LMrlm47WEk6zPDs2lcbAgepI0Dn2+3tiBf5r4V1cggJ0kte/pdn1wPUn197KIAxzvdWADOZIE3qAuGGBDR4820rcCsJlfZ+D9ini5o7NAd1Pj0Lzlt+cPecLqDHSkZuQvXjWV/lK7j+H1KcqhqIxdWngB00KFttCHfcJzsmXfbwcS66h7tDPbrozv2bYa/sFkkR+iVRPWHJxW8eBQR/fJ/Y0nUH/C9Bwn7Ku4JipwesVgjuf0ib1PEFw0NWhV1x4v4iMBqemmquvJ444+4JXvND+ceFaReFMY5qM7l4ad7wS1butMwplGw7YC8Q0SvPPG+wvsH6MltT6uDBRegzjA/fQeGswl0y35e5RtHpGBzbqtfXDs+2lk4q1AVbe2Ccem2mdddcvVQUd+TbDAAmlzL+e2E2D2ycrlG37h37f1EeCJd7wyVHyjw8LfwKEjSTRU2sXfRNz8mWiPcdS6Xq9sdT7n2ME78PUJvB+Cj0/obLiyduNeXTO/2bb79ypSfOHq+oLgkPN1HDdZK205g97X4twaqqrduFMaeoN/V2NrZd07M+RQcCsazxXCpjA4s3sQE+QBu6r2lhMGD//g5J7th+fPrzf7rMCjOPtzQeyAvJA9jlfoweoVm97Upbj/5N6tb8ELczp4E034jIVDe6MRBiKC+wGUz49sXGN97dh0yonSnFg+OhzJAbECVCOqps+qWX+R44iHEbiczXHEKRJCQH0uZwLnpZUrNvX69zy1LVoRi0rxIaYZi4ETWei0Y1+LmzgDK1vFv2DhvhkN5MHxYfcU3RdY7et6lSNCZWXXfXI97bkEB6zvaIbn09CkHE19WQRYaNcILyOysF06b+0XbxnoPanrTKdXJArVshfbD4hxAAqH48ELS+jvK7+6fs3RctZb2crmgZ5Lqf+xfiJIjMa1xRYTl8ytu+NGlGBTMPoDEjg7eSUaUuqJIMpSUBopx64zGkowpvSMdrnzMHa3fkg/AH7fGrF7hanR2RJEgKUH8cqXuM4/gWjMQ3gmbhdx4XwC12hqoM+O1CAwjOq0gSzwGpp2BWMNao5KZgDydjcYUYj6CH5CI5j8LGBbECPz0fE678Dw5XPr6svRy9shVbkgcwBS+u8KTmPHQVsWGHBd8Gx7bXZIC6lhQltgBpTFacBZ7R+hKx3ov48GkofCq6JmKEITx9lC4WxGez8AfW2AywITl4eGe2spGjOagBmPFwbPnp6FcyQ4SSAX0AAqGJRhhBKh8cQd7IQ9ELYG2ggJQvmy950dQ9hkvxhvEgEYKin499pPn9ldUTRjFzfZJ3AOIEcIB6MKZmF0Llr5WsmIzS6h4DrCG8MYlhw0eRnlH9uNvYniGV4pRioxCOChOBawB+7N8RSFgWM2zv59HcSZYcuu0EfkEAicQdseMAVN1uCZn3nzS6EIVqmmGd9FWx4h+cUD3uBhH86nU28wLeoI99o/cXJHtCwjJ4jvaHwD+OjgS+wVCtVfdKQ/wAJq68Nne4PoQwMQGHgxsTi6ElGC1QdGDeM8XBbs0UKf4HPRx3IwEKPJsF+gYFAvMaHENob7Dr3UT7/efTvIQVAwLYIXIgA73ovvroA4qxtFz8FuvgSIPbBrCmHY1i9Bm9inYBaYqHbvoAbFlE8t2aFhkoJY4yNoZ4DeIoL09AAfICBKpo7TBbENI5Xb3320aYjgODNOEx6Cw3hmaxjkyDNycMDlzDvbh4h27CR2RfIBJ7Qx2xykadlarkX9kwaPb2tiTmyrlYiij8tTGDqJD+Es1By5BFtfBYZhaMK2/w6UpUCeH2s44YoBl0uqazfNNIDJCovgqf1bX0soB5V0wpMx7I0EqpZtuMceFnrAgcw1vqA8tS3tK9EpTTpWP0RsG6KUN8O2eeywU4NqO8fgSngQpv4MTnUeh0UyQfRBHrarksdrqRmyHGDs6GlJ9ayUJDIKJP34xImCIrhxO39cYDDUZromRCmOpBE2hUMxkAYHxmwIknEU4rpQCHkVBO4CGjU8H8DBm2tGhUDVi/6R1PNHEZsVlqOM8XEULEad+Chjn9auWrlhhRT6x2A7mI6xLeA5Z2bNr7+PpkuQ1RXUDjp/ys4y/2wGrDPocCWkEfnsJ4mtJd537nrqXbjnk5G8RgHvPjuxPNk9BCm+ioqYJj67ctn6/4F25YBgfGMGPaElmsbfitcnE8ZkCTz5vTBZJjz8x2CKAQemGawnwkAFDXnW9L2wM3eijKLU82maAvE9iNFZnXw3gzjPouKOhujAOaWEvV1D84Rhky43TM/d8I6q2HHsjv58dj+mCp4+bi9UmYK9jTlmZ8XyDSTxlZCGRVQ+zFJO9tHg5D87pSQIswLd8H4OzgGHKkgbcRHOM7zN3llTc5fZwWB1KElWyHX9K7ijnpnqhVXHbg52h/fHGYgSA9JyGA6ZJtF5YEYeNHpE6Pbrmm3ER47wjSaO3vG7If9tkFLYGD6iyjBUMRiMgY7D2J2Mh/CVDHkpSKA9WVEWLrK7CvpnM5tfQPslaH+oesX6pZB+UmWA8Llg8mxrOK9DZ0MxdIlXjol+RDebmpQ5SCxMeg9BH82nwZdnbTtMp1yvheSZEJ52W4Tu7vY/P1JUhLdMc2PQ3BYYdBBJqj2AOCpOQFj397bsGIgzEG8VMXu47x0jt6gdCC8klYULbZVDhSdZNgx50iSl5eU7u181SHXjCf1XEk4ZXBdev9P6TOnAhS+aec6fQGgt2VocTrShdgswv8uChKI1fhss8C1oFV6XXljEvq1tLypxgq3qHJnCjvGPJnx1bhMLK6lgcvmGb0B/+hIEPwY25grLErdtRCCej3PLuQ029wnYtZvA0jJT99HXR6KOB3cEJ51T3DQ/yALBESvoC3YPd9vRD5JFzKZqBSwizwUSX1d2gCoK9kbeyBmSiBQMhLnAGzcRVSJ1iqtUDB5t43sshw5Z3UcbYWMj/QfhJKFk8zHPjIASz1FOL2NEpAr5WG0sU7ShUF3hlKke3cO0VELQl9EPj8WwmYLyKRGmyB3dRxtFFvx1ZIkaKwQZtPEP0xWZtHPDA2rWxYpjVzDbwcnVbsCeUf3ArAJlqo1RCYxCYwqxF03dTI+6xg94vbkSSzB0Kk5TFFJduGk5K7FsUysUTLpEhVWy/zTrUqqMgdC5IdZjTfmQzQLzYc7mKTwcDgsJpmeJRqov2Vl461sdljWoG9ZMsOm3yMRSiy0ZLs3RWKAfH40gODkPUrsKFU9iTK/BPBNTHHBLE31G2NfvGGGaaNMALMNq51K87D/oSOdGfPZOcRWD1StsC4MRGSNUVUwPcesVUxpDYFQuurCO1dy1GTNFVIraQKIVL9UQzeNTTFJAW8RuWZo8QN6SxA8qfKgPb+tAYuJwEQQxGydNLCIfcmyxw7HlDjS5vct3ulRo+hZVHxmwbt90rMA+MG87RAAHfNS07hksg3yQjgUKnybf9e/z/rlz3+/3+5t7n4dNbKN8NDp/mA0bUO8/qqWUhvqMbYd678bq5AaSS3zboMMZlEfaWEsruLQHZcjk+D6NaIJj2AP2KmGAo+hhXqs5S/pgzyP00zKK2unes/0YGHAE9TEefGGF0bWITAyKFNPA/6TMo7rEGBoF8CHyFg5WPW+g371g6GBwxHw728g3MFLUEEYklmK2iHpAXljmRH9ZYcvr7djT8zKY/i2gH1a2TOPzcEVUB2+zC3vrwNn+H1vhYTgUhu/MkOZqb0TVH7TgFKvgeEbSWJk3ZL0f08sGGPEXoIL4rxfhUo0JqAG4DgzyF7ve2N5FZgLa+gU4giNoCzM+rQx75BE4yeAAnM/7X326PSyVQ1SMS+gSpn7iWWoSA4UB02/ALfVX9TnRJBBMYjIQpagjKB6ylFp17ftdFwz0DWCA0fNaY0cPVgxlfm0TpMVnm3oHVUaXv47LA7RqoudIgkJhkmSeaocB3mP7z6z9XlmJZwcaWI0aH8WvWWjiWTk01DT49svDBfPrpZOnfxgosLjnkJ7RhGH5Lzw9RMsyO8jf7T687cyM5Wtv9elZdcySt6KXcyApj0st+EqHd7AFsIoOTOJfn7ng42uMPAQjHMzXNA6JlY9Jw3rFbw4cI7juEdZbVcBh53gWNC0eWjsbCj9c4DMPKqPJnUg/JbsTdbLhCQP+Q4th9+LxDWRH0v8BbhkCukZ3pX0AAAAASUVORK5CYII=)"
+              ]
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "width": 1,
+            "height": 2
+          }
+        },
+        {
+          "widget": {
+            "name": "sankey-reach-flow-cpd",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "ucmv_data",
+                  "fields": [
+                    {
+                      "name": "campaign",
+                      "expression": "`campaign`"
+                    },
+                    {
+                      "name": "publisher",
+                      "expression": "`publisher`"
+                    },
+                    {
+                      "name": "device_type",
+                      "expression": "`device_type`"
+                    },
+                    {
+                      "name": "countdistinct(mc_indid)",
+                      "expression": "COUNT(DISTINCT `mc_indid`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 1,
+              "widgetType": "sankey",
+              "encodings": {
+                "stages": [
+                  {
+                    "fieldName": "campaign",
+                    "displayName": "Campaign"
+                  },
+                  {
+                    "fieldName": "publisher",
+                    "displayName": "Publisher"
+                  },
+                  {
+                    "fieldName": "device_type",
+                    "displayName": "Device Type"
+                  }
+                ],
+                "value": {
+                  "fieldName": "countdistinct(mc_indid)",
+                  "displayName": "Individual Reach"
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "How Publisher Mix Shapes Device Type Reach"
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 15,
+            "width": 24,
+            "height": 15
+          }
+        }
+      ],
+      "pageType": "PAGE_TYPE_CANVAS",
+      "layoutVersion": "GRID_V1"
+    },
+    {
+      "name": "dim-explorer-1a21afe0",
+      "displayName": "Dimension Explorer",
+      "layout": [
+        {
+          "widget": {
+            "name": "dim-intro",
+            "multilineTextboxSpec": {
+              "lines": [
+                "Filter by publisher, device type, inventory type, content, and region to explore reach for each dimension combination."
+              ]
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "width": 12,
+            "height": 1
+          }
+        },
+        {
+          "widget": {
+            "name": "filter-publisher",
+            "queries": [
+              {
+                "name": "ds_filter-publisher",
+                "query": {
+                  "datasetName": "cube_detail_data",
+                  "fields": [
+                    {
+                      "name": "publisher",
+                      "expression": "`publisher`"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "filter-multi-select",
+              "encodings": {
+                "fields": [
+                  {
+                    "fieldName": "publisher",
+                    "displayName": "Publisher",
+                    "queryName": "ds_filter-publisher"
+                  }
+                ]
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Publisher"
+              }
+            }
+          },
+          "position": {
+            "x": 4,
+            "y": 1,
+            "width": 4,
+            "height": 2
+          }
+        },
+        {
+          "widget": {
+            "name": "filter-device-type",
+            "queries": [
+              {
+                "name": "ds_filter-device-type",
+                "query": {
+                  "datasetName": "cube_detail_data",
+                  "fields": [
+                    {
+                      "name": "device_type",
+                      "expression": "`device_type`"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "filter-multi-select",
+              "encodings": {
+                "fields": [
+                  {
+                    "fieldName": "device_type",
+                    "displayName": "Device Type",
+                    "queryName": "ds_filter-device-type"
+                  }
+                ]
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Device Type"
+              }
+            }
+          },
+          "position": {
+            "x": 8,
+            "y": 1,
+            "width": 4,
+            "height": 2
+          }
+        },
+        {
+          "widget": {
+            "name": "table-dims",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "cube_detail_data",
+                  "fields": [
+                    {
+                      "name": "campaign",
+                      "expression": "`campaign`"
+                    },
+                    {
+                      "name": "publisher",
+                      "expression": "`publisher`"
+                    },
+                    {
+                      "name": "device_type",
+                      "expression": "`device_type`"
+                    },
+                    {
+                      "name": "inventory_type",
+                      "expression": "`inventory_type`"
+                    },
+                    {
+                      "name": "content",
+                      "expression": "`content`"
+                    },
+                    {
+                      "name": "marketing_region",
+                      "expression": "`marketing_region`"
+                    },
+                    {
+                      "name": "reach_ind",
+                      "expression": "`reach_ind`"
+                    },
+                    {
+                      "name": "reach_hhid",
+                      "expression": "`reach_hhid`"
+                    },
+                    {
+                      "name": "matched_imps",
+                      "expression": "`matched_imps`"
+                    },
+                    {
+                      "name": "raw_imps",
+                      "expression": "`raw_imps`"
+                    }
+                  ],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "table",
+              "encodings": {
+                "columns": [
+                  {
+                    "fieldName": "campaign",
+                    "displayName": "Campaign"
+                  },
+                  {
+                    "fieldName": "publisher",
+                    "displayName": "Publisher"
+                  },
+                  {
+                    "fieldName": "device_type",
+                    "displayName": "Device Type"
+                  },
+                  {
+                    "fieldName": "inventory_type",
+                    "displayName": "Inventory Type"
+                  },
+                  {
+                    "fieldName": "content",
+                    "displayName": "Content"
+                  },
+                  {
+                    "fieldName": "marketing_region",
+                    "displayName": "Marketing Region"
+                  },
+                  {
+                    "fieldName": "reach_ind",
+                    "displayName": "Individual Reach"
+                  },
+                  {
+                    "fieldName": "reach_hhid",
+                    "displayName": "Household Reach"
+                  },
+                  {
+                    "fieldName": "matched_imps",
+                    "displayName": "Matched Imps"
+                  },
+                  {
+                    "fieldName": "raw_imps",
+                    "displayName": "Raw Imps"
+                  }
+                ]
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "All Dimension Combinations"
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 5,
+            "width": 12,
+            "height": 9
+          }
+        },
+        {
+          "widget": {
+            "name": "filter-inventory-type",
+            "queries": [
+              {
+                "name": "ds_filter-inventory-type",
+                "query": {
+                  "datasetName": "cube_detail_data",
+                  "fields": [
+                    {
+                      "name": "inventory_type",
+                      "expression": "`inventory_type`"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "filter-multi-select",
+              "encodings": {
+                "fields": [
+                  {
+                    "fieldName": "inventory_type",
+                    "displayName": "Inventory Type",
+                    "queryName": "ds_filter-inventory-type"
+                  }
+                ]
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Inventory Type"
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 3,
+            "width": 4,
+            "height": 2
+          }
+        },
+        {
+          "widget": {
+            "name": "filter-content",
+            "queries": [
+              {
+                "name": "ds_filter-content",
+                "query": {
+                  "datasetName": "cube_detail_data",
+                  "fields": [
+                    {
+                      "name": "content",
+                      "expression": "`content`"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "filter-multi-select",
+              "encodings": {
+                "fields": [
+                  {
+                    "fieldName": "content",
+                    "displayName": "Content",
+                    "queryName": "ds_filter-content"
+                  }
+                ]
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Content"
+              }
+            }
+          },
+          "position": {
+            "x": 4,
+            "y": 3,
+            "width": 4,
+            "height": 2
+          }
+        },
+        {
+          "widget": {
+            "name": "filter-region",
+            "queries": [
+              {
+                "name": "ds_filter-region",
+                "query": {
+                  "datasetName": "cube_detail_data",
+                  "fields": [
+                    {
+                      "name": "marketing_region",
+                      "expression": "`marketing_region`"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "filter-multi-select",
+              "encodings": {
+                "fields": [
+                  {
+                    "fieldName": "marketing_region",
+                    "displayName": "Marketing Region",
+                    "queryName": "ds_filter-region"
+                  }
+                ]
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Marketing Region"
+              }
+            }
+          },
+          "position": {
+            "x": 8,
+            "y": 3,
+            "width": 4,
+            "height": 2
+          }
+        },
+        {
+          "widget": {
+            "name": "filter-campaign-p2",
+            "queries": [
+              {
+                "name": "ds_filter-campaign-p2",
+                "query": {
+                  "datasetName": "cube_detail_data",
+                  "fields": [
+                    {
+                      "name": "campaign",
+                      "expression": "`campaign`"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "filter-multi-select",
+              "encodings": {
+                "fields": [
+                  {
+                    "fieldName": "campaign",
+                    "displayName": "Campaign",
+                    "queryName": "ds_filter-campaign-p2"
+                  }
+                ]
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Campaign"
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 1,
+            "width": 4,
+            "height": 2
+          }
+        }
+      ],
+      "pageType": "PAGE_TYPE_CANVAS"
+    }
+  ],
+  "uiSettings": {
+    "theme": {
+      "widgetHeaderAlignment": "ALIGNMENT_UNSPECIFIED"
+    },
+    "applyModeEnabled": false
+  }
+}

--- a/adtech_series_sp26/measurement/src/reach_pipeline/transformations/reach_pipeline.py
+++ b/adtech_series_sp26/measurement/src/reach_pipeline/transformations/reach_pipeline.py
@@ -1,0 +1,383 @@
+from functools import reduce
+from pyspark import pipelines as dp
+from pyspark.sql import functions as F
+from pyspark.sql import Window
+
+# ---------------------------------------------------------------------------
+# Pipeline parameters
+# Defined in resources/reach_pipeline.pipeline.yml under configuration:
+# ---------------------------------------------------------------------------
+source_catalog    = spark.conf.get("source_catalog")     # media_advertising
+source_schema     = spark.conf.get("source_schema")      # bronze
+source_table      = spark.conf.get("source_table")       # impression_logs_prod
+campaigns_catalog = spark.conf.get("campaigns_catalog")  # media_advertising
+campaigns_schema  = spark.conf.get("campaigns_schema")   # segments
+campaigns_table   = spark.conf.get("campaigns_table")    # megacorp_campaigns
+
+# ---------------------------------------------------------------------------
+# IFA prefix helpers
+# Both device_type and inventory_type are derived from the same source column
+# (request_kv._server_ifa) but use different CASE WHEN logic and different
+# fallback values: device_type falls back to "Web"; inventory_type to "Other".
+#
+# IFA prefixes → device classification:
+#   rida, tifa, vida, afai, lgudid  → CTV   (connected TV identifiers)
+#   idfa, aaid                      → Mobile (mobile ad identifiers)
+#   all others / NULL               → Web    (device_type) or Other (inventory_type)
+# ---------------------------------------------------------------------------
+_CTV_PREFIXES    = ["rida", "tifa", "vida", "afai", "lgudid"]
+_MOBILE_PREFIXES = ["idfa", "aaid"]
+
+def _ifa_prefix_col():
+    """Extract the prefix (part before ':') from request_kv._server_ifa."""
+    return F.split(F.col("request_kv._server_ifa"), ":")[0]
+
+
+def _device_type_col():
+    """CTV / Mobile / Web — device environment dimension."""
+    p = _ifa_prefix_col()
+    return (
+        F.when(p.isin(_CTV_PREFIXES),    F.lit("CTV"))
+         .when(p.isin(_MOBILE_PREFIXES), F.lit("Mobile"))
+         .otherwise(F.lit("Web"))
+    )
+
+
+def _inventory_type_col():
+    """CTV / Mobile / Other — ad inventory channel dimension.
+
+    Identical CTV/Mobile mapping to device_type, but the fallback is 'Other'
+    (not 'Web') because web/unknown inventory is categorised as open/standard.
+    CTV inventory is predominantly purchased as guaranteed deals (premium).
+    """
+    p = _ifa_prefix_col()
+    return (
+        F.when(p.isin(_CTV_PREFIXES),    F.lit("CTV"))
+         .when(p.isin(_MOBILE_PREFIXES), F.lit("Mobile"))
+         .otherwise(F.lit("Other"))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 1a: COPPA filter + audience join + struct flatten + enrichment
+#
+# @dp.temporary_view — no catalog table created.
+# Exists only within the pipeline execution context.
+#
+# Filters applied (in order of earliest exclusion):
+#   1. request_kv._is_coppa == False  — exclude COPPA-flagged records first
+#   2. meta_info.is_target  == True   — retain only audience-matched impressions
+#   3. INNER JOIN megacorp_campaigns  — brings in megacorp_hhid (household ID)
+#
+# Enrichment:
+#   - device_type      from IFA prefix → CTV / Mobile / Web
+#   - inventory_type   from IFA prefix → CTV / Mobile / Other (separate CASE WHEN)
+#   - marketing_region via LEFT JOIN on zip3_marketing_region (ZIP3 prefix lookup)
+#   - ip_address       retained as-is for IP reach deduplication
+#   - server_email     from request_kv._server_email for email reach deduplication
+# ---------------------------------------------------------------------------
+@dp.temporary_view(name="reach_impressions_filtered")
+def reach_impressions_filtered():
+    impressions = (
+        spark.read.table(f"{source_catalog}.{source_schema}.{source_table}")
+        .filter(F.col("request_kv._is_coppa") == False)
+        .filter(F.col("meta_info.is_target") == True)
+    )
+
+    # Deduplicate the audience table — one row per (individual, campaign)
+    audience = (
+        spark.read.table(f"{campaigns_catalog}.{campaigns_schema}.{campaigns_table}")
+        .select("megacorp_indid", "megacorp_hhid", "campaign_name")
+        .dropDuplicates(["megacorp_indid", "campaign_name"])
+    )
+
+    # ZIP3 → marketing region lookup; alias avoids column name ambiguity after join
+    zip_lookup = (
+        spark.read.table("media_advertising.gold.zip3_marketing_region")
+        .select(F.col("zip3"), F.col("marketing_region").alias("_marketing_region"))
+    )
+
+    return (
+        impressions
+        .join(audience, on=["megacorp_indid", "campaign_name"], how="inner")
+        .join(zip_lookup, on=F.substring(F.col("user_zip"), 1, 3) == F.col("zip3"), how="left")
+        .select(
+            "impression_id",
+            "date",
+            F.col("distributor_name").alias("publisher"),
+            F.col("campaign_name").alias("campaign"),
+            F.col("megacorp_indid").alias("mc_indid"),
+            F.col("megacorp_hhid").alias("hhid"),
+            F.col("content_nm").alias("content"),
+            "ip_address",
+            F.col("request_kv._server_email").alias("server_email"),
+            _device_type_col().alias("device_type"),
+            _inventory_type_col().alias("inventory_type"),
+            F.coalesce(F.col("_marketing_region"), F.lit("Other")).alias("marketing_region"),
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 1b: Raw impression counts by dimension — for raw_imps in gold cube
+#
+# @dp.temporary_view — no catalog table created.
+#
+# Reads impression_logs_prod WITHOUT the COPPA filter and WITHOUT the audience
+# join. Applies the same IFA-prefix enrichment and ZIP3 lookup so that raw_imps
+# aligns with the same dimension grain as the filtered silver metrics.
+#
+# Aggregates to: (campaign, publisher, content, device_type, inventory_type,
+#                 marketing_region) → raw impression count.
+#
+# The gold cube LEFT JOINs this view to add raw_imps alongside matched_imps.
+# raw_imps will always be >= matched_imps for every row (COPPA + join reduce).
+# ---------------------------------------------------------------------------
+@dp.temporary_view(name="raw_impressions_by_dim")
+def raw_impressions_by_dim():
+    zip_lookup = (
+        spark.read.table("media_advertising.gold.zip3_marketing_region")
+        .select(F.col("zip3"), F.col("marketing_region").alias("_marketing_region"))
+    )
+
+    return (
+        spark.read.table(f"{source_catalog}.{source_schema}.{source_table}")
+        .join(zip_lookup, on=F.substring(F.col("user_zip"), 1, 3) == F.col("zip3"), how="left")
+        .select(
+            F.col("campaign_name").alias("campaign"),
+            F.col("distributor_name").alias("publisher"),
+            F.col("content_nm").alias("content"),
+            _device_type_col().alias("device_type"),
+            _inventory_type_col().alias("inventory_type"),
+            F.coalesce(F.col("_marketing_region"), F.lit("Other")).alias("marketing_region"),
+            "impression_id",
+        )
+        .groupBy("campaign", "publisher", "content", "device_type", "inventory_type", "marketing_region")
+        .agg(F.count("impression_id").alias("raw_imps"))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 2: Silver — individual-level daily aggregation
+#
+# @dp.materialized_view — full refresh on each pipeline run.
+# One row per (date × mc_indid × hhid × ip_address × server_email ×
+#              publisher × device_type × inventory_type × campaign × content ×
+#              marketing_region).
+#
+# ip_address and server_email are carried through the GROUP BY so the gold
+# cube can COUNT(DISTINCT ...) them accurately across all dates.
+#
+# Writes to: media_advertising.silver.reach_impressions
+#   (fully-qualified name in decorator overrides the pipeline-level gold default)
+# ---------------------------------------------------------------------------
+@dp.materialized_view(
+    name="media_advertising.silver.reach_impressions",
+    comment=(
+        "Individual-level daily impression aggregation. COPPA-filtered. "
+        "One row per mc_indid × hhid × ip_address × server_email × publisher × "
+        "device_type × inventory_type × campaign × content × marketing_region × date. "
+        "Source of truth for gold reach_cube — never query impression_logs_prod directly."
+    ),
+    cluster_by=["date"],
+)
+def reach_impressions():
+    return (
+        spark.read.table("reach_impressions_filtered")
+        .groupBy(
+            "date",
+            "mc_indid",
+            "hhid",
+            "ip_address",
+            "server_email",
+            "publisher",
+            "device_type",
+            "inventory_type",
+            "campaign",
+            "content",
+            "marketing_region",
+        )
+        .agg(F.count("impression_id").alias("imps"))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Silver — campaign-level aggregation with identity array strings
+#
+# @dp.materialized_view — full refresh on each pipeline run.
+#
+# Reads from:
+#   - media_advertising.silver.reach_impressions  (individual-level daily rows)
+#   - raw_impressions_by_dim                       (pre-filter raw counts, LEFT JOINed)
+#
+# Writes to: media_advertising.silver.reach_prelim
+#
+# One row per 6-dimension combination (no date). Identity keys are stored as
+# comma-joined strings via array_join(collect_set(...)), enabling correct
+# cross-combo deduplication in reach_cube rollup rows via
+# array_distinct(flatten(collect_list(split(...)))).
+# ---------------------------------------------------------------------------
+@dp.materialized_view(
+    name="media_advertising.silver.reach_prelim",
+    comment=(
+        "Campaign-level aggregation with no date dimension. "
+        "One row per (campaign × publisher × device_type × inventory_type × content × marketing_region). "
+        "Identity keys stored as comma-joined strings (array_join(collect_set(...))) enabling correct "
+        "cross-combo deduplication via array_distinct(flatten(split(...))) in reach_cube rollup rows."
+    ),
+    cluster_by=["campaign", "publisher"],
+)
+def reach_prelim():
+    _join_keys = ["campaign", "publisher", "device_type", "inventory_type", "content", "marketing_region"]
+    raw = spark.read.table("raw_impressions_by_dim")
+    return (
+        spark.read.table("media_advertising.silver.reach_impressions")
+        .groupBy(*_join_keys)
+        .agg(
+            F.array_join(F.collect_set("mc_indid"),    ",").alias("ind_ids"),
+            F.array_join(F.collect_set("hhid"),         ",").alias("hhid_ids"),
+            F.array_join(F.collect_set("ip_address"),   ",").alias("ip_ids"),
+            F.array_join(F.collect_set("server_email"), ",").alias("email_ids"),
+            F.sum("imps").alias("matched_imps"),
+        )
+        .join(raw, on=_join_keys, how="left")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 4: Gold — reach cube with detail rows + rollup rows
+#
+# @dp.materialized_view — full refresh on each pipeline run.
+#
+# Reads from: media_advertising.silver.reach_prelim
+#
+# Writes to: media_advertising.gold.reach_cube
+# Liquid Clustering on (campaign, publisher).
+#
+# Two passes UNION ALL'd:
+#   Pass 1 — detail rows: one per 6-dim combination, reach counts from string lengths
+#   Pass 2 — rollup rows: 6 rollup levels (one dim kept, rest = 'All'), plus
+#             campaign-total row (all dims = 'All') which replaces reach_totals.
+#
+# Rollup deduplication uses array_distinct(flatten(collect_list(split(...)))) —
+# mathematically correct across any dimension combination.
+# ---------------------------------------------------------------------------
+@dp.materialized_view(
+    name="reach_cube",
+    comment=(
+        "Reach metrics with detail rows (all 6 dims specific) and rollup rows (collapsed dims = 'All'). "
+        "Campaign-total rollup row (all dims = 'All') replaces reach_totals. "
+        "Rollup rows use array_distinct(flatten(...)) deduplication — correct at any grain. "
+        "COPPA-filtered. Do NOT query impression_logs_prod directly."
+    ),
+    cluster_by=["campaign", "publisher"],
+)
+def reach_cube():
+    _all_cols = ["campaign", "publisher", "device_type", "inventory_type", "content", "marketing_region"]
+
+    prelim = spark.read.table("media_advertising.silver.reach_prelim")
+
+    # Pass 1: detail rows — reach counts derived from string lengths (size of comma-split array)
+    detail = prelim.select(
+        "campaign", "publisher", "device_type", "inventory_type", "content", "marketing_region",
+        F.size(F.split(F.col("ind_ids"),   ",")).alias("reach_ind"),
+        F.size(F.split(F.col("hhid_ids"),  ",")).alias("reach_hhid"),
+        F.size(F.split(F.col("ip_ids"),    ",")).alias("reach_ip"),
+        F.size(F.split(F.col("email_ids"), ",")).alias("reach_email"),
+        "matched_imps",
+        "raw_imps",
+    )
+
+    # Pass 2: rollup rows — merge identity arrays, deduplicate, count
+    def _rollup(df, group_cols):
+        return (
+            df.groupBy(*group_cols)
+            .agg(
+                F.size(F.array_distinct(F.flatten(F.collect_list(F.split(F.col("ind_ids"),   ","))))).alias("reach_ind"),
+                F.size(F.array_distinct(F.flatten(F.collect_list(F.split(F.col("hhid_ids"),  ","))))).alias("reach_hhid"),
+                F.size(F.array_distinct(F.flatten(F.collect_list(F.split(F.col("ip_ids"),    ","))))).alias("reach_ip"),
+                F.size(F.array_distinct(F.flatten(F.collect_list(F.split(F.col("email_ids"), ","))))).alias("reach_email"),
+                F.sum("matched_imps").alias("matched_imps"),
+                F.sum("raw_imps").alias("raw_imps"),
+            )
+            .select(
+                *[F.col(c) if c in group_cols else F.lit("All").alias(c) for c in _all_cols],
+                "reach_ind", "reach_hhid", "reach_ip", "reach_email", "matched_imps", "raw_imps",
+            )
+        )
+
+    rollups = [
+        # Per-campaign rollups (campaign always specific)
+        _rollup(prelim, ["campaign", "publisher"]),
+        _rollup(prelim, ["campaign", "device_type"]),
+        _rollup(prelim, ["campaign", "inventory_type"]),
+        _rollup(prelim, ["campaign", "content"]),
+        _rollup(prelim, ["campaign", "marketing_region"]),
+        _rollup(prelim, ["campaign"]),  # campaign-total row — replaces reach_totals
+        # Cross-campaign rollups (campaign='All') — enables 'All' in campaign filter
+        _rollup(prelim, ["publisher"]),
+        _rollup(prelim, ["device_type"]),
+        _rollup(prelim, ["inventory_type"]),
+        _rollup(prelim, ["content"]),
+        _rollup(prelim, ["marketing_region"]),
+        _rollup(prelim, []),            # grand total — all dims = 'All'
+    ]
+
+    return reduce(lambda a, b: a.unionAll(b), [detail] + rollups)
+
+
+# ---------------------------------------------------------------------------
+# Step 5: Gold — individual-level gold table for UCMV
+#
+# @dp.materialized_view — full refresh on each pipeline run.
+#
+# Reads from:
+#   - media_advertising.silver.reach_impressions  (individual rows)
+#   - raw_impressions_by_dim                       (pre-filter raw counts, LEFT JOINed)
+#
+# Writes to: media_advertising.gold.reach_individual
+#
+# One row per mc_indid × dimension combination. Used as source for the
+# campaign_reach_metrics Metric View, enabling COUNT(DISTINCT ...) measures
+# at any query grain without double-counting.
+#
+# raw_imps_kpi: ROW_NUMBER() marks the first individual per dimension
+# combination as the carrier of raw_imps. SUM(raw_imps_kpi) is additive
+# and correct at any grain.
+# ---------------------------------------------------------------------------
+@dp.materialized_view(
+    name="reach_individual",
+    comment=(
+        "Individual-level gold table. One row per mc_indid × dimension combination. "
+        "Used as source for campaign_reach_metrics UCMV to enable COUNT(DISTINCT ...) "
+        "measures at any query grain. raw_imps_kpi attributes raw impression counts to "
+        "one row per dimension combination via ROW_NUMBER, making SUM(raw_imps_kpi) "
+        "correct at any grain."
+    ),
+    cluster_by=["campaign", "publisher"],
+)
+def reach_individual():
+    _join_keys = ["campaign", "publisher", "content", "device_type", "inventory_type", "marketing_region"]
+
+    w = Window.partitionBy(*_join_keys).orderBy("mc_indid")
+
+    silver = spark.read.table("media_advertising.silver.reach_impressions")
+    raw = spark.read.table("raw_impressions_by_dim")
+
+    return (
+        silver
+        .join(raw, on=_join_keys, how="left")
+        .withColumn("rn", F.row_number().over(w))
+        .withColumn(
+            "raw_imps_kpi",
+            F.when(F.col("rn") == 1, F.col("raw_imps")).otherwise(F.lit(0)),
+        )
+        .drop("rn", "raw_imps")
+    )
+
+
+# reach_totals removed (Phase 11 / T052).
+# Campaign-total reach is now the rollup row in reach_cube where all dims = 'All'.
+# Use: SELECT reach_ind FROM reach_cube WHERE campaign = ? AND publisher = 'All'
+#        AND device_type = 'All' AND inventory_type = 'All'
+#        AND content = 'All' AND marketing_region = 'All'

--- a/adtech_series_sp26/measurement/tables/zip3_marketing_region.sql
+++ b/adtech_series_sp26/measurement/tables/zip3_marketing_region.sql
@@ -1,0 +1,138 @@
+-- Table: zip3_marketing_region
+-- Feature: AdTech Series Measurement Demo
+--
+-- Purpose: Lookup table mapping 3-digit ZIP prefixes to named US advertising markets.
+--          JOIN'd directly in the pipeline on SUBSTRING(user_zip, 1, 3) = zip3.
+--          Update rows here to remap regions — no pipeline redeploy needed.
+--
+-- Deploy: databricks sql execute --warehouse-id <warehouse_id> \
+--           --file tables/zip3_marketing_region.sql --profile <profile>
+
+CREATE OR REPLACE TABLE media_advertising.gold.zip3_marketing_region (
+  zip3             STRING  NOT NULL COMMENT 'Three-digit ZIP prefix (000–999)',
+  marketing_region STRING  NOT NULL COMMENT 'Named US advertising market'
+)
+USING DELTA
+COMMENT 'Lookup table mapping ZIP3 prefixes to US advertising markets. \
+JOIN'd directly in the pipeline on SUBSTRING(user_zip, 1, 3) = zip3. \
+Update rows here to remap regions — no pipeline redeploy needed.';
+
+INSERT OVERWRITE media_advertising.gold.zip3_marketing_region VALUES
+  -- Puerto Rico: 006-009
+  ('006','Puerto Rico'), ('007','Puerto Rico'), ('008','Puerto Rico'), ('009','Puerto Rico'),
+  -- Western New England: 010-017
+  ('010','Western New England'), ('011','Western New England'), ('012','Western New England'), ('013','Western New England'), ('014','Western New England'), ('015','Western New England'), ('016','Western New England'), ('017','Western New England'),
+  -- Eastern Massachusetts: 018-019
+  ('018','Eastern Massachusetts'), ('019','Eastern Massachusetts'),
+  -- Boston Metro: 020-029
+  ('020','Boston Metro'), ('021','Boston Metro'), ('022','Boston Metro'), ('023','Boston Metro'), ('024','Boston Metro'), ('025','Boston Metro'), ('026','Boston Metro'), ('027','Boston Metro'), ('028','Boston Metro'), ('029','Boston Metro'),
+  -- New Hampshire: 030-038
+  ('030','New Hampshire'), ('031','New Hampshire'), ('032','New Hampshire'), ('033','New Hampshire'), ('034','New Hampshire'), ('035','New Hampshire'), ('036','New Hampshire'), ('037','New Hampshire'), ('038','New Hampshire'),
+  -- Maine: 039-049
+  ('039','Maine'), ('040','Maine'), ('041','Maine'), ('042','Maine'), ('043','Maine'), ('044','Maine'), ('045','Maine'), ('046','Maine'), ('047','Maine'), ('048','Maine'), ('049','Maine'),
+  -- Vermont: 050-059
+  ('050','Vermont'), ('051','Vermont'), ('052','Vermont'), ('053','Vermont'), ('054','Vermont'), ('055','Vermont'), ('056','Vermont'), ('057','Vermont'), ('058','Vermont'), ('059','Vermont'),
+  -- Connecticut: 060-069
+  ('060','Connecticut'), ('061','Connecticut'), ('062','Connecticut'), ('063','Connecticut'), ('064','Connecticut'), ('065','Connecticut'), ('066','Connecticut'), ('067','Connecticut'), ('068','Connecticut'), ('069','Connecticut'),
+  -- New Jersey Metro: 070-089
+  ('070','New Jersey Metro'), ('071','New Jersey Metro'), ('072','New Jersey Metro'), ('073','New Jersey Metro'), ('074','New Jersey Metro'), ('075','New Jersey Metro'), ('076','New Jersey Metro'), ('077','New Jersey Metro'), ('078','New Jersey Metro'), ('079','New Jersey Metro'), ('080','New Jersey Metro'), ('081','New Jersey Metro'), ('082','New Jersey Metro'), ('083','New Jersey Metro'), ('084','New Jersey Metro'), ('085','New Jersey Metro'), ('086','New Jersey Metro'), ('087','New Jersey Metro'), ('088','New Jersey Metro'), ('089','New Jersey Metro'),
+  -- APO/FPO: 090-099
+  ('090','APO/FPO'), ('091','APO/FPO'), ('092','APO/FPO'), ('093','APO/FPO'), ('094','APO/FPO'), ('095','APO/FPO'), ('096','APO/FPO'), ('097','APO/FPO'), ('098','APO/FPO'), ('099','APO/FPO'),
+  -- New York City Metro: 100-104
+  ('100','New York City Metro'), ('101','New York City Metro'), ('102','New York City Metro'), ('103','New York City Metro'), ('104','New York City Metro'),
+  -- Hudson Valley: 105-119
+  ('105','Hudson Valley'), ('106','Hudson Valley'), ('107','Hudson Valley'), ('108','Hudson Valley'), ('109','Hudson Valley'), ('110','Hudson Valley'), ('111','Hudson Valley'), ('112','Hudson Valley'), ('113','Hudson Valley'), ('114','Hudson Valley'), ('115','Hudson Valley'), ('116','Hudson Valley'), ('117','Hudson Valley'), ('118','Hudson Valley'), ('119','Hudson Valley'),
+  -- Upstate New York: 120-149
+  ('120','Upstate New York'), ('121','Upstate New York'), ('122','Upstate New York'), ('123','Upstate New York'), ('124','Upstate New York'), ('125','Upstate New York'), ('126','Upstate New York'), ('127','Upstate New York'), ('128','Upstate New York'), ('129','Upstate New York'), ('130','Upstate New York'), ('131','Upstate New York'), ('132','Upstate New York'), ('133','Upstate New York'), ('134','Upstate New York'), ('135','Upstate New York'), ('136','Upstate New York'), ('137','Upstate New York'), ('138','Upstate New York'), ('139','Upstate New York'), ('140','Upstate New York'), ('141','Upstate New York'), ('142','Upstate New York'), ('143','Upstate New York'), ('144','Upstate New York'), ('145','Upstate New York'), ('146','Upstate New York'), ('147','Upstate New York'), ('148','Upstate New York'), ('149','Upstate New York'),
+  -- Pittsburgh Metro: 150-168
+  ('150','Pittsburgh Metro'), ('151','Pittsburgh Metro'), ('152','Pittsburgh Metro'), ('153','Pittsburgh Metro'), ('154','Pittsburgh Metro'), ('155','Pittsburgh Metro'), ('156','Pittsburgh Metro'), ('157','Pittsburgh Metro'), ('158','Pittsburgh Metro'), ('159','Pittsburgh Metro'), ('160','Pittsburgh Metro'), ('161','Pittsburgh Metro'), ('162','Pittsburgh Metro'), ('163','Pittsburgh Metro'), ('164','Pittsburgh Metro'), ('165','Pittsburgh Metro'), ('166','Pittsburgh Metro'), ('167','Pittsburgh Metro'), ('168','Pittsburgh Metro'),
+  -- Philadelphia Metro: 170-196
+  ('170','Philadelphia Metro'), ('171','Philadelphia Metro'), ('172','Philadelphia Metro'), ('173','Philadelphia Metro'), ('174','Philadelphia Metro'), ('175','Philadelphia Metro'), ('176','Philadelphia Metro'), ('177','Philadelphia Metro'), ('178','Philadelphia Metro'), ('179','Philadelphia Metro'), ('180','Philadelphia Metro'), ('181','Philadelphia Metro'), ('182','Philadelphia Metro'), ('183','Philadelphia Metro'), ('184','Philadelphia Metro'), ('185','Philadelphia Metro'), ('186','Philadelphia Metro'), ('187','Philadelphia Metro'), ('188','Philadelphia Metro'), ('189','Philadelphia Metro'), ('190','Philadelphia Metro'), ('191','Philadelphia Metro'), ('192','Philadelphia Metro'), ('193','Philadelphia Metro'), ('194','Philadelphia Metro'), ('195','Philadelphia Metro'), ('196','Philadelphia Metro'),
+  -- Delaware: 197-199
+  ('197','Delaware'), ('198','Delaware'), ('199','Delaware'),
+  -- Washington DC Metro: 200-212
+  ('200','Washington DC Metro'), ('201','Washington DC Metro'), ('202','Washington DC Metro'), ('203','Washington DC Metro'), ('204','Washington DC Metro'), ('205','Washington DC Metro'), ('206','Washington DC Metro'), ('207','Washington DC Metro'), ('208','Washington DC Metro'), ('209','Washington DC Metro'), ('210','Washington DC Metro'), ('211','Washington DC Metro'), ('212','Washington DC Metro'),
+  -- Baltimore Metro: 213-219
+  ('213','Baltimore Metro'), ('214','Baltimore Metro'), ('215','Baltimore Metro'), ('216','Baltimore Metro'), ('217','Baltimore Metro'), ('218','Baltimore Metro'), ('219','Baltimore Metro'),
+  -- Virginia: 220-246
+  ('220','Virginia'), ('221','Virginia'), ('222','Virginia'), ('223','Virginia'), ('224','Virginia'), ('225','Virginia'), ('226','Virginia'), ('227','Virginia'), ('228','Virginia'), ('229','Virginia'), ('230','Virginia'), ('231','Virginia'), ('232','Virginia'), ('233','Virginia'), ('234','Virginia'), ('235','Virginia'), ('236','Virginia'), ('237','Virginia'), ('238','Virginia'), ('239','Virginia'), ('240','Virginia'), ('241','Virginia'), ('242','Virginia'), ('243','Virginia'), ('244','Virginia'), ('245','Virginia'), ('246','Virginia'),
+  -- West Virginia: 247-268
+  ('247','West Virginia'), ('248','West Virginia'), ('249','West Virginia'), ('250','West Virginia'), ('251','West Virginia'), ('252','West Virginia'), ('253','West Virginia'), ('254','West Virginia'), ('255','West Virginia'), ('256','West Virginia'), ('257','West Virginia'), ('258','West Virginia'), ('259','West Virginia'), ('260','West Virginia'), ('261','West Virginia'), ('262','West Virginia'), ('263','West Virginia'), ('264','West Virginia'), ('265','West Virginia'), ('266','West Virginia'), ('267','West Virginia'), ('268','West Virginia'),
+  -- North Carolina: 270-289
+  ('270','North Carolina'), ('271','North Carolina'), ('272','North Carolina'), ('273','North Carolina'), ('274','North Carolina'), ('275','North Carolina'), ('276','North Carolina'), ('277','North Carolina'), ('278','North Carolina'), ('279','North Carolina'), ('280','North Carolina'), ('281','North Carolina'), ('282','North Carolina'), ('283','North Carolina'), ('284','North Carolina'), ('285','North Carolina'), ('286','North Carolina'), ('287','North Carolina'), ('288','North Carolina'), ('289','North Carolina'),
+  -- South Carolina: 290-299
+  ('290','South Carolina'), ('291','South Carolina'), ('292','South Carolina'), ('293','South Carolina'), ('294','South Carolina'), ('295','South Carolina'), ('296','South Carolina'), ('297','South Carolina'), ('298','South Carolina'), ('299','South Carolina'),
+  -- Atlanta Metro: 300-319
+  ('300','Atlanta Metro'), ('301','Atlanta Metro'), ('302','Atlanta Metro'), ('303','Atlanta Metro'), ('304','Atlanta Metro'), ('305','Atlanta Metro'), ('306','Atlanta Metro'), ('307','Atlanta Metro'), ('308','Atlanta Metro'), ('309','Atlanta Metro'), ('310','Atlanta Metro'), ('311','Atlanta Metro'), ('312','Atlanta Metro'), ('313','Atlanta Metro'), ('314','Atlanta Metro'), ('315','Atlanta Metro'), ('316','Atlanta Metro'), ('317','Atlanta Metro'), ('318','Atlanta Metro'), ('319','Atlanta Metro'),
+  -- Florida: 320-349
+  ('320','Florida'), ('321','Florida'), ('322','Florida'), ('323','Florida'), ('324','Florida'), ('325','Florida'), ('326','Florida'), ('327','Florida'), ('328','Florida'), ('329','Florida'), ('330','Florida'), ('331','Florida'), ('332','Florida'), ('333','Florida'), ('334','Florida'), ('335','Florida'), ('336','Florida'), ('337','Florida'), ('338','Florida'), ('339','Florida'), ('340','Florida'), ('341','Florida'), ('342','Florida'), ('343','Florida'), ('344','Florida'), ('345','Florida'), ('346','Florida'), ('347','Florida'), ('348','Florida'), ('349','Florida'),
+  -- Alabama: 350-369
+  ('350','Alabama'), ('351','Alabama'), ('352','Alabama'), ('353','Alabama'), ('354','Alabama'), ('355','Alabama'), ('356','Alabama'), ('357','Alabama'), ('358','Alabama'), ('359','Alabama'), ('360','Alabama'), ('361','Alabama'), ('362','Alabama'), ('363','Alabama'), ('364','Alabama'), ('365','Alabama'), ('366','Alabama'), ('367','Alabama'), ('368','Alabama'), ('369','Alabama'),
+  -- Tennessee: 370-385
+  ('370','Tennessee'), ('371','Tennessee'), ('372','Tennessee'), ('373','Tennessee'), ('374','Tennessee'), ('375','Tennessee'), ('376','Tennessee'), ('377','Tennessee'), ('378','Tennessee'), ('379','Tennessee'), ('380','Tennessee'), ('381','Tennessee'), ('382','Tennessee'), ('383','Tennessee'), ('384','Tennessee'), ('385','Tennessee'),
+  -- Mississippi: 386-397
+  ('386','Mississippi'), ('387','Mississippi'), ('388','Mississippi'), ('389','Mississippi'), ('390','Mississippi'), ('391','Mississippi'), ('392','Mississippi'), ('393','Mississippi'), ('394','Mississippi'), ('395','Mississippi'), ('396','Mississippi'), ('397','Mississippi'),
+  -- Georgia (South): 398-399
+  ('398','Georgia (South)'), ('399','Georgia (South)'),
+  -- Kentucky: 400-427
+  ('400','Kentucky'), ('401','Kentucky'), ('402','Kentucky'), ('403','Kentucky'), ('404','Kentucky'), ('405','Kentucky'), ('406','Kentucky'), ('407','Kentucky'), ('408','Kentucky'), ('409','Kentucky'), ('410','Kentucky'), ('411','Kentucky'), ('412','Kentucky'), ('413','Kentucky'), ('414','Kentucky'), ('415','Kentucky'), ('416','Kentucky'), ('417','Kentucky'), ('418','Kentucky'), ('419','Kentucky'), ('420','Kentucky'), ('421','Kentucky'), ('422','Kentucky'), ('423','Kentucky'), ('424','Kentucky'), ('425','Kentucky'), ('426','Kentucky'), ('427','Kentucky'),
+  -- Ohio: 430-469
+  ('430','Ohio'), ('431','Ohio'), ('432','Ohio'), ('433','Ohio'), ('434','Ohio'), ('435','Ohio'), ('436','Ohio'), ('437','Ohio'), ('438','Ohio'), ('439','Ohio'), ('440','Ohio'), ('441','Ohio'), ('442','Ohio'), ('443','Ohio'), ('444','Ohio'), ('445','Ohio'), ('446','Ohio'), ('447','Ohio'), ('448','Ohio'), ('449','Ohio'), ('450','Ohio'), ('451','Ohio'), ('452','Ohio'), ('453','Ohio'), ('454','Ohio'), ('455','Ohio'), ('456','Ohio'), ('457','Ohio'), ('458','Ohio'), ('459','Ohio'), ('460','Ohio'), ('461','Ohio'), ('462','Ohio'), ('463','Ohio'), ('464','Ohio'), ('465','Ohio'), ('466','Ohio'), ('467','Ohio'), ('468','Ohio'), ('469','Ohio'),
+  -- Detroit Metro: 470-499
+  ('470','Detroit Metro'), ('471','Detroit Metro'), ('472','Detroit Metro'), ('473','Detroit Metro'), ('474','Detroit Metro'), ('475','Detroit Metro'), ('476','Detroit Metro'), ('477','Detroit Metro'), ('478','Detroit Metro'), ('479','Detroit Metro'), ('480','Detroit Metro'), ('481','Detroit Metro'), ('482','Detroit Metro'), ('483','Detroit Metro'), ('484','Detroit Metro'), ('485','Detroit Metro'), ('486','Detroit Metro'), ('487','Detroit Metro'), ('488','Detroit Metro'), ('489','Detroit Metro'), ('490','Detroit Metro'), ('491','Detroit Metro'), ('492','Detroit Metro'), ('493','Detroit Metro'), ('494','Detroit Metro'), ('495','Detroit Metro'), ('496','Detroit Metro'), ('497','Detroit Metro'), ('498','Detroit Metro'), ('499','Detroit Metro'),
+  -- Iowa: 500-528
+  ('500','Iowa'), ('501','Iowa'), ('502','Iowa'), ('503','Iowa'), ('504','Iowa'), ('505','Iowa'), ('506','Iowa'), ('507','Iowa'), ('508','Iowa'), ('509','Iowa'), ('510','Iowa'), ('511','Iowa'), ('512','Iowa'), ('513','Iowa'), ('514','Iowa'), ('515','Iowa'), ('516','Iowa'), ('517','Iowa'), ('518','Iowa'), ('519','Iowa'), ('520','Iowa'), ('521','Iowa'), ('522','Iowa'), ('523','Iowa'), ('524','Iowa'), ('525','Iowa'), ('526','Iowa'), ('527','Iowa'), ('528','Iowa'),
+  -- Wisconsin: 530-549
+  ('530','Wisconsin'), ('531','Wisconsin'), ('532','Wisconsin'), ('533','Wisconsin'), ('534','Wisconsin'), ('535','Wisconsin'), ('536','Wisconsin'), ('537','Wisconsin'), ('538','Wisconsin'), ('539','Wisconsin'), ('540','Wisconsin'), ('541','Wisconsin'), ('542','Wisconsin'), ('543','Wisconsin'), ('544','Wisconsin'), ('545','Wisconsin'), ('546','Wisconsin'), ('547','Wisconsin'), ('548','Wisconsin'), ('549','Wisconsin'),
+  -- Minneapolis Metro: 550-567
+  ('550','Minneapolis Metro'), ('551','Minneapolis Metro'), ('552','Minneapolis Metro'), ('553','Minneapolis Metro'), ('554','Minneapolis Metro'), ('555','Minneapolis Metro'), ('556','Minneapolis Metro'), ('557','Minneapolis Metro'), ('558','Minneapolis Metro'), ('559','Minneapolis Metro'), ('560','Minneapolis Metro'), ('561','Minneapolis Metro'), ('562','Minneapolis Metro'), ('563','Minneapolis Metro'), ('564','Minneapolis Metro'), ('565','Minneapolis Metro'), ('566','Minneapolis Metro'), ('567','Minneapolis Metro'),
+  -- North / South Dakota: 570-588
+  ('570','North / South Dakota'), ('571','North / South Dakota'), ('572','North / South Dakota'), ('573','North / South Dakota'), ('574','North / South Dakota'), ('575','North / South Dakota'), ('576','North / South Dakota'), ('577','North / South Dakota'), ('578','North / South Dakota'), ('579','North / South Dakota'), ('580','North / South Dakota'), ('581','North / South Dakota'), ('582','North / South Dakota'), ('583','North / South Dakota'), ('584','North / South Dakota'), ('585','North / South Dakota'), ('586','North / South Dakota'), ('587','North / South Dakota'), ('588','North / South Dakota'),
+  -- Montana: 590-599
+  ('590','Montana'), ('591','Montana'), ('592','Montana'), ('593','Montana'), ('594','Montana'), ('595','Montana'), ('596','Montana'), ('597','Montana'), ('598','Montana'), ('599','Montana'),
+  -- Chicago Metro: 600-629
+  ('600','Chicago Metro'), ('601','Chicago Metro'), ('602','Chicago Metro'), ('603','Chicago Metro'), ('604','Chicago Metro'), ('605','Chicago Metro'), ('606','Chicago Metro'), ('607','Chicago Metro'), ('608','Chicago Metro'), ('609','Chicago Metro'), ('610','Chicago Metro'), ('611','Chicago Metro'), ('612','Chicago Metro'), ('613','Chicago Metro'), ('614','Chicago Metro'), ('615','Chicago Metro'), ('616','Chicago Metro'), ('617','Chicago Metro'), ('618','Chicago Metro'), ('619','Chicago Metro'), ('620','Chicago Metro'), ('621','Chicago Metro'), ('622','Chicago Metro'), ('623','Chicago Metro'), ('624','Chicago Metro'), ('625','Chicago Metro'), ('626','Chicago Metro'), ('627','Chicago Metro'), ('628','Chicago Metro'), ('629','Chicago Metro'),
+  -- St. Louis Metro: 630-658
+  ('630','St. Louis Metro'), ('631','St. Louis Metro'), ('632','St. Louis Metro'), ('633','St. Louis Metro'), ('634','St. Louis Metro'), ('635','St. Louis Metro'), ('636','St. Louis Metro'), ('637','St. Louis Metro'), ('638','St. Louis Metro'), ('639','St. Louis Metro'), ('640','St. Louis Metro'), ('641','St. Louis Metro'), ('642','St. Louis Metro'), ('643','St. Louis Metro'), ('644','St. Louis Metro'), ('645','St. Louis Metro'), ('646','St. Louis Metro'), ('647','St. Louis Metro'), ('648','St. Louis Metro'), ('649','St. Louis Metro'), ('650','St. Louis Metro'), ('651','St. Louis Metro'), ('652','St. Louis Metro'), ('653','St. Louis Metro'), ('654','St. Louis Metro'), ('655','St. Louis Metro'), ('656','St. Louis Metro'), ('657','St. Louis Metro'), ('658','St. Louis Metro'),
+  -- Kansas: 660-679
+  ('660','Kansas'), ('661','Kansas'), ('662','Kansas'), ('663','Kansas'), ('664','Kansas'), ('665','Kansas'), ('666','Kansas'), ('667','Kansas'), ('668','Kansas'), ('669','Kansas'), ('670','Kansas'), ('671','Kansas'), ('672','Kansas'), ('673','Kansas'), ('674','Kansas'), ('675','Kansas'), ('676','Kansas'), ('677','Kansas'), ('678','Kansas'), ('679','Kansas'),
+  -- Omaha Metro: 680-693
+  ('680','Omaha Metro'), ('681','Omaha Metro'), ('682','Omaha Metro'), ('683','Omaha Metro'), ('684','Omaha Metro'), ('685','Omaha Metro'), ('686','Omaha Metro'), ('687','Omaha Metro'), ('688','Omaha Metro'), ('689','Omaha Metro'), ('690','Omaha Metro'), ('691','Omaha Metro'), ('692','Omaha Metro'), ('693','Omaha Metro'),
+  -- New Orleans Metro: 700-714
+  ('700','New Orleans Metro'), ('701','New Orleans Metro'), ('702','New Orleans Metro'), ('703','New Orleans Metro'), ('704','New Orleans Metro'), ('705','New Orleans Metro'), ('706','New Orleans Metro'), ('707','New Orleans Metro'), ('708','New Orleans Metro'), ('709','New Orleans Metro'), ('710','New Orleans Metro'), ('711','New Orleans Metro'), ('712','New Orleans Metro'), ('713','New Orleans Metro'), ('714','New Orleans Metro'),
+  -- Arkansas: 716-729
+  ('716','Arkansas'), ('717','Arkansas'), ('718','Arkansas'), ('719','Arkansas'), ('720','Arkansas'), ('721','Arkansas'), ('722','Arkansas'), ('723','Arkansas'), ('724','Arkansas'), ('725','Arkansas'), ('726','Arkansas'), ('727','Arkansas'), ('728','Arkansas'), ('729','Arkansas'),
+  -- Oklahoma: 730-749
+  ('730','Oklahoma'), ('731','Oklahoma'), ('732','Oklahoma'), ('733','Oklahoma'), ('734','Oklahoma'), ('735','Oklahoma'), ('736','Oklahoma'), ('737','Oklahoma'), ('738','Oklahoma'), ('739','Oklahoma'), ('740','Oklahoma'), ('741','Oklahoma'), ('742','Oklahoma'), ('743','Oklahoma'), ('744','Oklahoma'), ('745','Oklahoma'), ('746','Oklahoma'), ('747','Oklahoma'), ('748','Oklahoma'), ('749','Oklahoma'),
+  -- Dallas / Houston Metro: 750-799
+  ('750','Dallas / Houston Metro'), ('751','Dallas / Houston Metro'), ('752','Dallas / Houston Metro'), ('753','Dallas / Houston Metro'), ('754','Dallas / Houston Metro'), ('755','Dallas / Houston Metro'), ('756','Dallas / Houston Metro'), ('757','Dallas / Houston Metro'), ('758','Dallas / Houston Metro'), ('759','Dallas / Houston Metro'), ('760','Dallas / Houston Metro'), ('761','Dallas / Houston Metro'), ('762','Dallas / Houston Metro'), ('763','Dallas / Houston Metro'), ('764','Dallas / Houston Metro'), ('765','Dallas / Houston Metro'), ('766','Dallas / Houston Metro'), ('767','Dallas / Houston Metro'), ('768','Dallas / Houston Metro'), ('769','Dallas / Houston Metro'), ('770','Dallas / Houston Metro'), ('771','Dallas / Houston Metro'), ('772','Dallas / Houston Metro'), ('773','Dallas / Houston Metro'), ('774','Dallas / Houston Metro'), ('775','Dallas / Houston Metro'), ('776','Dallas / Houston Metro'), ('777','Dallas / Houston Metro'), ('778','Dallas / Houston Metro'), ('779','Dallas / Houston Metro'), ('780','Dallas / Houston Metro'), ('781','Dallas / Houston Metro'), ('782','Dallas / Houston Metro'), ('783','Dallas / Houston Metro'), ('784','Dallas / Houston Metro'), ('785','Dallas / Houston Metro'), ('786','Dallas / Houston Metro'), ('787','Dallas / Houston Metro'), ('788','Dallas / Houston Metro'), ('789','Dallas / Houston Metro'), ('790','Dallas / Houston Metro'), ('791','Dallas / Houston Metro'), ('792','Dallas / Houston Metro'), ('793','Dallas / Houston Metro'), ('794','Dallas / Houston Metro'), ('795','Dallas / Houston Metro'), ('796','Dallas / Houston Metro'), ('797','Dallas / Houston Metro'), ('798','Dallas / Houston Metro'), ('799','Dallas / Houston Metro'),
+  -- Denver Metro: 800-816
+  ('800','Denver Metro'), ('801','Denver Metro'), ('802','Denver Metro'), ('803','Denver Metro'), ('804','Denver Metro'), ('805','Denver Metro'), ('806','Denver Metro'), ('807','Denver Metro'), ('808','Denver Metro'), ('809','Denver Metro'), ('810','Denver Metro'), ('811','Denver Metro'), ('812','Denver Metro'), ('813','Denver Metro'), ('814','Denver Metro'), ('815','Denver Metro'), ('816','Denver Metro'),
+  -- Wyoming / Idaho: 820-838
+  ('820','Wyoming / Idaho'), ('821','Wyoming / Idaho'), ('822','Wyoming / Idaho'), ('823','Wyoming / Idaho'), ('824','Wyoming / Idaho'), ('825','Wyoming / Idaho'), ('826','Wyoming / Idaho'), ('827','Wyoming / Idaho'), ('828','Wyoming / Idaho'), ('829','Wyoming / Idaho'), ('830','Wyoming / Idaho'), ('831','Wyoming / Idaho'), ('832','Wyoming / Idaho'), ('833','Wyoming / Idaho'), ('834','Wyoming / Idaho'), ('835','Wyoming / Idaho'), ('836','Wyoming / Idaho'), ('837','Wyoming / Idaho'), ('838','Wyoming / Idaho'),
+  -- Salt Lake City Metro: 840-847
+  ('840','Salt Lake City Metro'), ('841','Salt Lake City Metro'), ('842','Salt Lake City Metro'), ('843','Salt Lake City Metro'), ('844','Salt Lake City Metro'), ('845','Salt Lake City Metro'), ('846','Salt Lake City Metro'), ('847','Salt Lake City Metro'),
+  -- Phoenix Metro: 850-865
+  ('850','Phoenix Metro'), ('851','Phoenix Metro'), ('852','Phoenix Metro'), ('853','Phoenix Metro'), ('854','Phoenix Metro'), ('855','Phoenix Metro'), ('856','Phoenix Metro'), ('857','Phoenix Metro'), ('858','Phoenix Metro'), ('859','Phoenix Metro'), ('860','Phoenix Metro'), ('861','Phoenix Metro'), ('862','Phoenix Metro'), ('863','Phoenix Metro'), ('864','Phoenix Metro'), ('865','Phoenix Metro'),
+  -- New Mexico: 870-884
+  ('870','New Mexico'), ('871','New Mexico'), ('872','New Mexico'), ('873','New Mexico'), ('874','New Mexico'), ('875','New Mexico'), ('876','New Mexico'), ('877','New Mexico'), ('878','New Mexico'), ('879','New Mexico'), ('880','New Mexico'), ('881','New Mexico'), ('882','New Mexico'), ('883','New Mexico'), ('884','New Mexico'),
+  -- Las Vegas Metro: 885-893
+  ('885','Las Vegas Metro'), ('886','Las Vegas Metro'), ('887','Las Vegas Metro'), ('888','Las Vegas Metro'), ('889','Las Vegas Metro'), ('890','Las Vegas Metro'), ('891','Las Vegas Metro'), ('892','Las Vegas Metro'), ('893','Las Vegas Metro'),
+  -- Los Angeles Metro: 900-928
+  ('900','Los Angeles Metro'), ('901','Los Angeles Metro'), ('902','Los Angeles Metro'), ('903','Los Angeles Metro'), ('904','Los Angeles Metro'), ('905','Los Angeles Metro'), ('906','Los Angeles Metro'), ('907','Los Angeles Metro'), ('908','Los Angeles Metro'), ('909','Los Angeles Metro'), ('910','Los Angeles Metro'), ('911','Los Angeles Metro'), ('912','Los Angeles Metro'), ('913','Los Angeles Metro'), ('914','Los Angeles Metro'), ('915','Los Angeles Metro'), ('916','Los Angeles Metro'), ('917','Los Angeles Metro'), ('918','Los Angeles Metro'), ('919','Los Angeles Metro'), ('920','Los Angeles Metro'), ('921','Los Angeles Metro'), ('922','Los Angeles Metro'), ('923','Los Angeles Metro'), ('924','Los Angeles Metro'), ('925','Los Angeles Metro'), ('926','Los Angeles Metro'), ('927','Los Angeles Metro'), ('928','Los Angeles Metro'),
+  -- Central California: 930-939
+  ('930','Central California'), ('931','Central California'), ('932','Central California'), ('933','Central California'), ('934','Central California'), ('935','Central California'), ('936','Central California'), ('937','Central California'), ('938','Central California'), ('939','Central California'),
+  -- San Francisco / Bay Area: 940-969
+  ('940','San Francisco / Bay Area'), ('941','San Francisco / Bay Area'), ('942','San Francisco / Bay Area'), ('943','San Francisco / Bay Area'), ('944','San Francisco / Bay Area'), ('945','San Francisco / Bay Area'), ('946','San Francisco / Bay Area'), ('947','San Francisco / Bay Area'), ('948','San Francisco / Bay Area'), ('949','San Francisco / Bay Area'), ('950','San Francisco / Bay Area'), ('951','San Francisco / Bay Area'), ('952','San Francisco / Bay Area'), ('953','San Francisco / Bay Area'), ('954','San Francisco / Bay Area'), ('955','San Francisco / Bay Area'), ('956','San Francisco / Bay Area'), ('957','San Francisco / Bay Area'), ('958','San Francisco / Bay Area'), ('959','San Francisco / Bay Area'), ('960','San Francisco / Bay Area'), ('961','San Francisco / Bay Area'), ('962','San Francisco / Bay Area'), ('963','San Francisco / Bay Area'), ('964','San Francisco / Bay Area'), ('965','San Francisco / Bay Area'), ('966','San Francisco / Bay Area'), ('967','San Francisco / Bay Area'), ('968','San Francisco / Bay Area'), ('969','San Francisco / Bay Area'),
+  -- Portland Metro: 970-979
+  ('970','Portland Metro'), ('971','Portland Metro'), ('972','Portland Metro'), ('973','Portland Metro'), ('974','Portland Metro'), ('975','Portland Metro'), ('976','Portland Metro'), ('977','Portland Metro'), ('978','Portland Metro'), ('979','Portland Metro'),
+  -- Seattle Metro: 980-994
+  ('980','Seattle Metro'), ('981','Seattle Metro'), ('982','Seattle Metro'), ('983','Seattle Metro'), ('984','Seattle Metro'), ('985','Seattle Metro'), ('986','Seattle Metro'), ('987','Seattle Metro'), ('988','Seattle Metro'), ('989','Seattle Metro'), ('990','Seattle Metro'), ('991','Seattle Metro'), ('992','Seattle Metro'), ('993','Seattle Metro'), ('994','Seattle Metro'),
+  -- Alaska: 995-999
+  ('995','Alaska'), ('996','Alaska'), ('997','Alaska'), ('998','Alaska'), ('999','Alaska');
+
+-- ── Validation ────────────────────────────────────────────────────────────────
+-- SELECT COUNT(*) FROM media_advertising.gold.zip3_marketing_region;  -- → 961
+-- SELECT * FROM media_advertising.gold.zip3_marketing_region WHERE zip3 = '902';  -- → 'Los Angeles Metro'
+-- SELECT * FROM media_advertising.gold.zip3_marketing_region WHERE zip3 = '100';  -- → 'New York City Metro'
+-- SELECT * FROM media_advertising.gold.zip3_marketing_region WHERE zip3 = '606';  -- → 'Chicago Metro'


### PR DESCRIPTION
## Summary

Adds **Session 4 of the AdTech SP26 series** (Measurement) to `adtech_series_sp26/measurement/`. Replaces the existing `.gitkeep` placeholder with a complete, deployable project. No files outside `adtech_series_sp26/measurement/` are touched.

## What's included

- **Spark Declarative Pipeline** — COPPA filter → silver aggregations → gold reach cube (12 rollup levels) + individual-level table
- **Unity Catalog Function** (`compute_reach`) — scalar reach count, callable from SQL/Genie/dashboards
- **Unity Catalog Metric View** (`campaign_reach_metrics`) — governed semantic layer (DBR 17.2+, YAML v1.1)
- **AI/BI Dashboard** — KPIs, reach-by-dimension charts, Sankey, dimension explorer (deployed as a bundle resource)
- **Genie Space** — natural-language Q&A with REST-API authoring, round-trip pull script, and an 11-case routing eval suite
- **Lookup table** — ZIP3 → marketing region mapping
- **Quickstart** in `docs/quickstart.md` — deployment + verification queries at every step

## Workspace-agnostic

- Bundle YAML has no hardcoded workspace host or warehouse ID — uses Databricks CLI profile + `--var warehouse_id=...`
- Genie space JSON has `space_id: null` and `warehouse_id: null` — deploy script requires `--warehouse-id` and prints `space_id` on fresh create
- SQL files reference `media_advertising.gold` directly; bundle pipeline is fully parameterized via `${var.catalog}` etc.

## Test plan

- [x] `databricks bundle validate` passes with profile-based auth
- [x] All 11 Genie eval cases pass (`python genie_spaces/eval_genie_space.py --space-id <id> --warehouse-id <id>`)
- [x] UC function (`compute_reach('Terrific Tacos')`) returns expected reach
- [x] Metric View `MEASURE(\`Individual Reach\`)` matches UC function output
- [x] Live dashboard + Genie space verified end-to-end in `e2-demo-field-eng`
- [ ] Deployer to confirm `bundle deploy && bundle run reach_pipeline` succeeds in their target workspace