### PR TITLE
Update .gitignore to exclude frontend dist directory from being ignored

### DIFF
--- a/adtech_series_sp26/.gitignore
+++ b/adtech_series_sp26/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 # Node
 node_modules/
 dist/
+!**/campaign_pacing_app/frontend/dist/
 
 # Databricks
 .databricks/


### PR DESCRIPTION
Small fix that allows the dist artifact to not be ignored by the DAB